### PR TITLE
Update dcp-prototype references to corpora-data-portal

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,13 @@
-# DCP Prototype
-![Push Tests](https://github.com/HumanCellAtlas/dcp-prototype/workflows/Push%20Tests/badge.svg)
+# Corpora Data Portal
+![Push Tests](https://github.com/chanzuckerberg/corpora-data-portal/workflows/Push%20Tests/badge.svg)
 [![codecov](https://codecov.io/gh/chanzuckerberg/dcp-prototype/branch/master/graph/badge.svg)](https://codecov.io/gh/chanzuckerberg/dcp-prototype)
 
-The Data Coordination Platform (DCP) stores, organizes, serves, and enables the exploration of cell atlases.
+The Corpora Data Portal (CDP) enables the publication, discovery and exploration of interoperable
+single-cell datasets. Data contributors can upload, review and publish datasets for private or
+public use. Via the portal, data consumers are able to discover, download and connect data to visualization tools
+such as [cellxgene](https://chanzuckerberg.github.io/cellxgene/posts/cellxgene_cziscience_com) to perform further
+analysis. The goal of the CDP is to catalyze distributed collaboration of single-cell research by providing a large,
+well-labeled repository of interoperable datasets.
 
 ## Developer guide
 

--- a/browser/backend/README.md
+++ b/browser/backend/README.md
@@ -15,7 +15,7 @@ Filename                  | Purpose                           | Information link
 
 ## Development
 1.  Ensure your `awscli` is configured with the
-    [required credentials and profiles](https://github.com/chanzuckerberg/dcp-prototype#configuration).
+    [required credentials and profiles](https://github.com/chanzuckerberg/corpora-data-portal#configuration).
 
 1.  Set the following environment variables:
 
@@ -58,9 +58,9 @@ To redeploy your app after updating, run `make deploy` again. To undeploy the ap
 run `make destroy`.
 
 ## Testing
-Tests are run in the top level directory `dcp-prototype`.
+Tests are run in the top level directory `corpora-data-portal`.
 
-See the [top level README](https://github.com/chanzuckerberg/dcp-prototype/blob/master/README.md#testing)
+See the [top level README](https://github.com/chanzuckerberg/corpora-data-portal/blob/master/README.md#testing)
 for how to run tests.
 
 ## Managing the Lambda IAM role and assume role policy

--- a/browser/backend/README.md
+++ b/browser/backend/README.md
@@ -1,6 +1,6 @@
-# Browser Backend
+# Portal Backend
 
-This application serves as the API for the Data Browser website.
+This application serves as the API for the Data Portal website.
 
 # Chalice App Overview
 

--- a/browser/backend/scripts/generate_test_artifact.py
+++ b/browser/backend/scripts/generate_test_artifact.py
@@ -1,5 +1,5 @@
 """
-Generates a stripped-down test JSON artifact to be stored in `tests/unit/dcp-prototype/backend/browser/fixtures`
+Generates a stripped-down test JSON artifact to be stored in `tests/unit/browser/backend/fixtures`
 - Reads an existing JSON artifact from S3
 - Selects a subset of files and their respectives projects
 - Writes a new `test_artifact.json` to the current directory

--- a/browser/frontend/README.md
+++ b/browser/frontend/README.md
@@ -25,7 +25,7 @@
     
 1.  **Host the backend locally.**
 
-    Follow [backend instructions](https://github.com/chanzuckerberg/dcp-prototype/tree/master/browser/backend#development)
+    Follow [backend instructions](https://github.com/chanzuckerberg/corpora-data-portal/tree/master/browser/backend#development)
     to deploy the backend API on `http://localhost:5000`.
 
 1.  **Build and launch the frontend locally.**
@@ -43,7 +43,7 @@
 ## Deployment
 
 1.  Ensure your `awscli` is configured with the
-    [required credentials and profiles](https://github.com/chanzuckerberg/dcp-prototype#configuration).
+    [required credentials and profiles](https://github.com/chanzuckerberg/corpora-data-portal#configuration).
     Set the appropriate `AWS_PROFILE`.
 
     ```shell

--- a/browser/lambdas/chalice/cloudfront-invalidator/README.md
+++ b/browser/lambdas/chalice/cloudfront-invalidator/README.md
@@ -17,7 +17,7 @@ Filename                  | Purpose                           | Information link
 
 ## Development
 1.  Ensure your `awscli` is configured with the
-    [required credentials and profiles](https://github.com/chanzuckerberg/dcp-prototype#configuration).
+    [required credentials and profiles](https://github.com/chanzuckerberg/corpora-data-portal#configuration).
 
 1.  Set the following environment variables:
 
@@ -57,7 +57,7 @@ To redeploy your app after updating, run `make deploy` again. To undeploy the ap
 run `make destroy`.
 
 ## Testing
-Tests are run in the top level directory [dcp_prototpye](../../../README.md).
+Tests are run in the top level directory [corpora-data-portal](../../../README.md).
 
 See the [top level README](../../../README.md#testing)
 for how to run tests.


### PR DESCRIPTION
Closes #299

Nt: `codecov` badge still points to `dcp-prototype`. This will be addressed in #314 