### PR TITLE
Storing deployed config in git

### DIFF
--- a/backend/chalice/api_server/.chalice/deployed/dev.json
+++ b/backend/chalice/api_server/.chalice/deployed/dev.json
@@ -3,7 +3,7 @@
     {
       "name": "api_handler_role",
       "resource_type": "iam_role",
-      "role_arn": "arn:aws:iam::699936264352:role/data-portal-api-dev-api_handler",
+      "role_arn": "arn:aws:iam::699936264352:role/corpora-api-dev-api_handler",
       "role_name": "corpora-api-dev-api_handler"
     },
     {

--- a/backend/chalice/api_server/.chalice/deployed/dev.json
+++ b/backend/chalice/api_server/.chalice/deployed/dev.json
@@ -1,0 +1,23 @@
+{
+  "resources": [
+    {
+      "name": "api_handler_role",
+      "resource_type": "iam_role",
+      "role_arn": "arn:aws:iam::699936264352:role/data-portal-api-dev-api_handler",
+      "role_name": "corpora-api-dev-api_handler"
+    },
+    {
+      "name": "api_handler",
+      "resource_type": "lambda_function",
+      "lambda_arn": "arn:aws:lambda:us-west-2:699936264352:function:corpora-api-dev"
+    },
+    {
+      "name": "rest_api",
+      "resource_type": "rest_api",
+      "rest_api_id": "670bpw5cqf",
+      "rest_api_url": "https://670bpw5cqf.execute-api.us-west-2.amazonaws.com/dev/"
+    }
+  ],
+  "schema_version": "2.0",
+  "backend": "api"
+}

--- a/backend/chalice/api_server/.chalice/deployed/staging.json
+++ b/backend/chalice/api_server/.chalice/deployed/staging.json
@@ -1,0 +1,5 @@
+{
+  "resources": [],
+  "schema_version": "2.0",
+  "backend": "api"
+}

--- a/backend/chalice/api_server/.chalice/deployed/staging.json
+++ b/backend/chalice/api_server/.chalice/deployed/staging.json
@@ -1,5 +1,23 @@
 {
-  "resources": [],
+  "resources": [
+    {
+      "name": "api_handler_role",
+      "resource_type": "iam_role",
+      "role_arn": "arn:aws:iam::699936264352:role/corpora-api-staging-api_handler",
+      "role_name": "corpora-api-staging-api_handler"
+    },
+    {
+      "name": "api_handler",
+      "resource_type": "lambda_function",
+      "lambda_arn": "arn:aws:lambda:us-west-2:699936264352:function:corpora-api-staging"
+    },
+    {
+      "name": "rest_api",
+      "resource_type": "rest_api",
+      "rest_api_id": "w8hiclkmfa",
+      "rest_api_url": "https://w8hiclkmfa.execute-api.us-west-2.amazonaws.com/staging/"
+    }
+  ],
   "schema_version": "2.0",
   "backend": "api"
 }

--- a/backend/chalice/api_server/.gitignore
+++ b/backend/chalice/api_server/.gitignore
@@ -1,6 +1,5 @@
 .chalice/deployments/
 .chalice/venv/
-.chalice/deployed/
 .chalice/config.json
 .chalice/policy-*.json
 chalicelib

--- a/backend/chalice/api_server/Makefile
+++ b/backend/chalice/api_server/Makefile
@@ -1,13 +1,9 @@
 SHELL=/bin/bash -o pipefail
 
 # This is set for build reproducibility
-export ACCOUNT_ID=$(shell aws sts get-caller-identity --query Account --output text)
 export APP_NAME=corpora-api
 export EXPORT_ENV_VARS_TO_LAMBDA=APP_NAME DEPLOYMENT_STAGE
 export PYTHONHASHSEED=0
-export S3_DEPLOYMENT_FILE=s3://org-corpora-infra-$(ACCOUNT_ID)/chalice/envs/$(DEPLOYMENT_STAGE)/$(APP_NAME)_deployed.json
-export LOCAL_DEPLOYED_PATH=.chalice/deployed
-export LOCAL_DEPLOYED_FILE=$(LOCAL_DEPLOYED_PATH)/$(DEPLOYMENT_STAGE).json
 ifndef DEPLOYMENT_STAGE
 $(error Please set DEPLOYMENT_STAGE in environment before running make commands)
 endif
@@ -19,16 +15,13 @@ clean:
 .PHONY: destroy
 destroy:
 	chalice delete --stage $(DEPLOYMENT_STAGE)
-	make remove-deployed
-
 
 .PHONY: deploy
 deploy: package
 	chalice deploy --stage $(DEPLOYMENT_STAGE) --api-gateway-stage $(DEPLOYMENT_STAGE)
-	make upload-deployed
 
 .PHONY: ci-deploy
-ci-deploy: retrieve-deployed
+ci-deploy:
 	make deploy
 
 .PHONY: package
@@ -57,16 +50,3 @@ build-chalice-config:
 .PHONY: local-server
 local-server: package
 	python run_local_server.py
-
-.PHONY: retrieve-deployed
-retrieve-deployed:
-	if [[ ! -d "$(LOCAL_DEPLOYED_PATH)" ]]; then mkdir $(LOCAL_DEPLOYED_PATH); fi
-	aws s3 cp $(S3_DEPLOYMENT_FILE) $(LOCAL_DEPLOYED_FILE)
-
-.PHONY: upload-deployed
-upload-deployed:
-	aws s3 cp $(LOCAL_DEPLOYED_FILE) $(S3_DEPLOYMENT_FILE)
-
-.PHONY: remove-deployed
-remove-deployed:
-	aws s3 rm $(S3_DEPLOYMENT_FILE)

--- a/backend/chalice/cloudfront_invalidator/.chalice/deployed/dev.json
+++ b/backend/chalice/cloudfront_invalidator/.chalice/deployed/dev.json
@@ -1,0 +1,23 @@
+{
+  "resources": [
+    {
+      "name": "corpora-frontend_role",
+      "resource_type": "iam_role",
+      "role_arn": "arn:aws:iam::699936264352:role/cloudfront-invalidator-dev-corpora-frontend",
+      "role_name": "cloudfront-invalidator-dev-corpora-frontend"
+    },
+    {
+      "name": "corpora-frontend",
+      "resource_type": "lambda_function",
+      "lambda_arn": "arn:aws:lambda:us-west-2:699936264352:function:cloudfront-invalidator-dev-corpora-frontend"
+    },
+    {
+      "name": "corpora-frontend-s3event",
+      "resource_type": "s3_event",
+      "bucket": "corpora-static-site-dev-699936264352",
+      "lambda_arn": "arn:aws:lambda:us-west-2:699936264352:function:cloudfront-invalidator-dev-corpora-frontend"
+    }
+  ],
+  "schema_version": "2.0",
+  "backend": "api"
+}

--- a/backend/chalice/cloudfront_invalidator/Makefile
+++ b/backend/chalice/cloudfront_invalidator/Makefile
@@ -3,9 +3,6 @@ SHELL=/bin/bash -o pipefail
 # This is set for build reproducibility
 export ACCOUNT_ID=$(shell aws sts get-caller-identity --query Account --output text)
 export APP_NAME?=cloudfront-invalidator
-export S3_DEPLOYMENT_FILE=s3://org-corpora-infra-$(ACCOUNT_ID)/chalice/envs/$(DEPLOYMENT_STAGE)/$(APP_NAME)_deployed.json
-export LOCAL_DEPLOYED_PATH=.chalice/deployed
-export LOCAL_DEPLOYED_FILE=$(LOCAL_DEPLOYED_PATH)/$(DEPLOYMENT_STAGE).json
 ifndef DEPLOYMENT_STAGE
 $(error Please set DEPLOYMENT_STAGE in environment before running make commands)
 endif
@@ -18,7 +15,6 @@ clean:
 .PHONY: destroy
 destroy:
 	chalice delete --stage $(DEPLOYMENT_STAGE)
-	make remove-deployed
 
 .PHONY: package
 package: build-chalice-config
@@ -29,12 +25,6 @@ package: build-chalice-config
 .PHONY: deploy
 deploy: package
 	chalice deploy --stage $(DEPLOYMENT_STAGE)
-	make upload-deployed
-
-.PHONY: redeploy
-redeploy: retrieve-deployed package
-	chalice deploy --stage $(DEPLOYMENT_STAGE)
-	make upload-deployed
 
 .PHONY: build-chalice-config
 build-chalice-config:
@@ -48,16 +38,3 @@ build-chalice-config:
 	cd .chalice; jq .stages.$(DEPLOYMENT_STAGE).tags.env=env.DEPLOYMENT_STAGE config.json | sponge config.json
 	cd .chalice; jq .stages.$(DEPLOYMENT_STAGE).tags.service=env.APP_NAME config.json | sponge config.json
 	cd .chalice; jq .stages.$(DEPLOYMENT_STAGE).api_gateway_stage=env.DEPLOYMENT_STAGE config.json | sponge config.json
-
-.PHONY: retrieve-deployed
-retrieve-deployed:
-	if [[ ! -d "$(LOCAL_DEPLOYED_PATH)" ]]; then mkdir $(LOCAL_DEPLOYED_PATH); fi
-	aws s3 cp $(S3_DEPLOYMENT_FILE) $(LOCAL_DEPLOYED_FILE)
-
-.PHONY: upload-deployed
-upload-deployed:
-	aws s3 cp $(LOCAL_DEPLOYED_FILE) $(S3_DEPLOYMENT_FILE)
-
-.PHONY: remove-deployed
-remove-deployed:
-	aws s3 rm $(S3_DEPLOYMENT_FILE)


### PR DESCRIPTION
Adding the chalice deployed environment file in github. This is part of an effort to simplify the deployment process.