### PR TITLE
Default DEPLOYMENT_STAGE for tests=='test'

### DIFF
--- a/backend/corpora/common/authorizer.py
+++ b/backend/corpora/common/authorizer.py
@@ -40,7 +40,7 @@ def assert_authorized(headers: dict) -> dict:
 
         if os.getenv["DEPLOYMENT_STAGE"] not in ["test", "dev"]:
             """
-            In the test and dev environments we are using an Auth0 machine to machine access token which does not 
+            In the test and dev environments we are using an Auth0 machine to machine access token which does not
             connect to a user, therefore there is no userinfo to get.
             """
             payload["userinfo"] = get_userinfo(token)

--- a/backend/corpora/common/authorizer.py
+++ b/backend/corpora/common/authorizer.py
@@ -38,8 +38,12 @@ def assert_authorized(headers: dict) -> dict:
         except Exception:
             raise UnauthorizedError(msg="Unable to parse authentication token.")
 
-        if os.environ["DEPLOYMENT_STAGE"] not in ["test", "dev"]:
-            payload["userinfo"] = get_userinfo()
+        if os.getenv["DEPLOYMENT_STAGE"] not in ["test", "dev"]:
+            """
+            In the test and dev environments we are using an Auth0 machine to machine access token which does not 
+            connect to a user, therefore this call would fail.
+            """
+            payload["userinfo"] = get_userinfo(token)
 
         return payload
     raise UnauthorizedError(msg="Unable to find appropriate key")

--- a/backend/corpora/common/authorizer.py
+++ b/backend/corpora/common/authorizer.py
@@ -41,7 +41,7 @@ def assert_authorized(headers: dict) -> dict:
         if os.getenv["DEPLOYMENT_STAGE"] not in ["test", "dev"]:
             """
             In the test and dev environments we are using an Auth0 machine to machine access token which does not 
-            connect to a user, therefore this call would fail.
+            connect to a user, therefore there is no userinfo to get.
             """
             payload["userinfo"] = get_userinfo(token)
 

--- a/backend/corpora/common/authorizer.py
+++ b/backend/corpora/common/authorizer.py
@@ -38,9 +38,9 @@ def assert_authorized(headers: dict) -> dict:
         except Exception:
             raise UnauthorizedError(msg="Unable to parse authentication token.")
 
-        if os.environ["DEPLOYMENT_STAGE"] not in ["test", "dev"]:
+        if os.environ["DEPLOYMENT_STAGE"] != "test":
             """
-            In the test and dev environments we are using an Auth0 machine to machine access token which does not
+            In the test environments we are using an Auth0 machine to machine access token which does not
             connect to a user, therefore there is no userinfo to get.
             """
             payload["userinfo"] = get_userinfo(token)

--- a/backend/corpora/common/authorizer.py
+++ b/backend/corpora/common/authorizer.py
@@ -38,7 +38,7 @@ def assert_authorized(headers: dict) -> dict:
         except Exception:
             raise UnauthorizedError(msg="Unable to parse authentication token.")
 
-        if os.getenv["DEPLOYMENT_STAGE"] not in ["test", "dev"]:
+        if os.environ["DEPLOYMENT_STAGE"] not in ["test", "dev"]:
             """
             In the test and dev environments we are using an Auth0 machine to machine access token which does not
             connect to a user, therefore there is no userinfo to get.

--- a/backend/corpora/common/authorizer.py
+++ b/backend/corpora/common/authorizer.py
@@ -40,7 +40,7 @@ def assert_authorized(headers: dict) -> dict:
 
         if os.environ["DEPLOYMENT_STAGE"] != "test":
             """
-            In the test environments we are using an Auth0 machine to machine access token which does not
+            In the environments we are using an Auth0 machine to machine access token which does not
             connect to a user, therefore there is no userinfo to get.
             """
             payload["userinfo"] = get_userinfo(token)

--- a/backend/corpora/common/authorizer.py
+++ b/backend/corpora/common/authorizer.py
@@ -38,7 +38,7 @@ def assert_authorized(headers: dict) -> dict:
         except Exception:
             raise UnauthorizedError(msg="Unable to parse authentication token.")
 
-        if os.getenv("DEPLOYMENT_STAGE", "test").lower() not in ["test", "dev"]:
+        if os.environ["DEPLOYMENT_STAGE"] not in ["test", "dev"]:
             payload["userinfo"] = get_userinfo()
 
         return payload

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,4 +1,4 @@
 import os
 
-os.environ["DEPLOYMENT_STAGE"] = os.getenv("DEPLOYMENT_STAGE", "dev")
+os.environ["DEPLOYMENT_STAGE"] = os.getenv("DEPLOYMENT_STAGE", "test")
 os.environ["AWS_DEFAULT_REGION"] = "us-west-2"

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,4 +1,0 @@
-import os
-
-os.environ["DEPLOYMENT_STAGE"] = os.getenv("DEPLOYMENT_STAGE", "test")
-os.environ["AWS_DEFAULT_REGION"] = "us-west-2"

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,4 +1,4 @@
 import os
 
-os.environ["DEPLOYMENT_STAGE"] = os.getenv("DEPLOYMENT_STAGE", 'dev')
+os.environ["DEPLOYMENT_STAGE"] = os.getenv("DEPLOYMENT_STAGE", "dev")
 os.environ["AWS_DEFAULT_REGION"] = "us-west-2"

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,4 @@
+import os
+
+os.environ["DEPLOYMENT_STAGE"] = os.getenv("DEPLOYMENT_STAGE", 'dev')
+os.environ["AWS_DEFAULT_REGION"] = "us-west-2"

--- a/tests/functional/backend/corpora/test_api.py
+++ b/tests/functional/backend/corpora/test_api.py
@@ -6,8 +6,6 @@ import requests
 
 from backend.corpora.common.utils.aws_secret import AwsSecret
 
-if not os.getenv("DEPLOYMENT_STAGE"):  # noqa
-    os.environ["DEPLOYMENT_STAGE"] = "dev"  # noqa
 
 API_URL = {
     "dev": "https://api.dev.corpora.cziscience.com",

--- a/tests/unit/__init__.py
+++ b/tests/unit/__init__.py
@@ -1,4 +1,0 @@
-import os
-
-os.environ["DEPLOYMENT_STAGE"] = "test"
-os.environ["AWS_DEFAULT_REGION"] = "us-west-2"

--- a/tests/unit/backend/__init__.py
+++ b/tests/unit/backend/__init__.py
@@ -1,0 +1,4 @@
+import os
+
+os.environ["DEPLOYMENT_STAGE"] = "test"
+os.environ["AWS_DEFAULT_REGION"] = "us-west-2"

--- a/tests/unit/backend/corpora/common/test_authorizer.py
+++ b/tests/unit/backend/corpora/common/test_authorizer.py
@@ -10,12 +10,14 @@ from backend.corpora.common.utils.aws_secret import AwsSecret
 
 
 """
-Because of how auth0 is setup we only run these test on the dev environment. This prevent us from exhausting the number
-of machine to machine access tokens we can produce in a month for auth0.
+These test may start failing if the monthly allowence of Auth0 machine to machine access tokens is exhasted.
 """
 
 
-@unittest.skipIf(os.environ["DEPLOYMENT_STAGE"] != "dev", "DEPLOYMENT_STAGE is not 'dev'")
+@unittest.skipIf(
+    os.environ["DEPLOYMENT_STAGE"] != "test",
+    f"Does not run DEPLOYMENT_STAGE:{os.environ['DEPLOYMENT_STAGE']}",
+)
 class TestAuthorizer(unittest.TestCase):
     @classmethod
     def setUpClass(cls):

--- a/tests/unit/backend/corpora/common/test_authorizer.py
+++ b/tests/unit/backend/corpora/common/test_authorizer.py
@@ -13,6 +13,8 @@ from backend.corpora.common.utils.aws_secret import AwsSecret
 Because of how auth0 is setup we only run these test on the dev environment. This prevent us from exhausting the number
 of machine to machine access tokens we can produce in a month for auth0.
 """
+
+
 @unittest.skipIf(os.environ["DEPLOYMENT_STAGE"] != "dev", "DEPLOYMENT_STAGE is not 'dev'")
 class TestAuthorizer(unittest.TestCase):
     @classmethod

--- a/tests/unit/backend/corpora/common/test_authorizer.py
+++ b/tests/unit/backend/corpora/common/test_authorizer.py
@@ -9,7 +9,7 @@ from backend.corpora.common.authorizer import assert_authorized
 from backend.corpora.common.utils.aws_secret import AwsSecret
 
 
-@unittest.skipIf(os.getenv("DEPLOYMENT_STAGE"), "DEPLOYMENT_STAGE not set")
+@unittest.skipIf(os.environ["DEPLOYMENT_STAGE"] == "test", "DEPLOYMENT_STAGE cannot be 'test'")
 class TestAuthorizer(unittest.TestCase):
     @classmethod
     def setUpClass(cls):

--- a/tests/unit/backend/corpora/common/test_authorizer.py
+++ b/tests/unit/backend/corpora/common/test_authorizer.py
@@ -10,7 +10,7 @@ from backend.corpora.common.utils.aws_secret import AwsSecret
 
 
 """
-These test may start failing if the monthly allowence of Auth0 machine to machine access tokens is exhasted.
+These test may start failing if the monthly allowance of Auth0 machine to machine access tokens is exhasted.
 """
 
 

--- a/tests/unit/backend/corpora/common/test_authorizer.py
+++ b/tests/unit/backend/corpora/common/test_authorizer.py
@@ -15,8 +15,7 @@ These test may start failing if the monthly allowence of Auth0 machine to machin
 
 
 @unittest.skipIf(
-    os.environ["DEPLOYMENT_STAGE"] != "test",
-    f"Does not run DEPLOYMENT_STAGE:{os.environ['DEPLOYMENT_STAGE']}",
+    os.environ["DEPLOYMENT_STAGE"] != "test", f"Does not run DEPLOYMENT_STAGE:{os.environ['DEPLOYMENT_STAGE']}",
 )
 class TestAuthorizer(unittest.TestCase):
     @classmethod

--- a/tests/unit/backend/corpora/common/test_authorizer.py
+++ b/tests/unit/backend/corpora/common/test_authorizer.py
@@ -9,7 +9,11 @@ from backend.corpora.common.authorizer import assert_authorized
 from backend.corpora.common.utils.aws_secret import AwsSecret
 
 
-@unittest.skipIf(os.environ["DEPLOYMENT_STAGE"] == "test", "DEPLOYMENT_STAGE cannot be 'test'")
+"""
+Because of how auth0 is setup we only run these test on the dev environment. This prevent us from exhausting the number
+of machine to machine access tokens we can produce in a month for auth0.
+"""
+@unittest.skipIf(os.environ["DEPLOYMENT_STAGE"] != "dev", "DEPLOYMENT_STAGE is not 'dev'")
 class TestAuthorizer(unittest.TestCase):
     @classmethod
     def setUpClass(cls):


### PR DESCRIPTION
* If a different DEPLOYMENT_STAGE is set in the environment, that value is used.
* Adding documentation for why certain DEPLOYMENT_STAGEs are used.