### PR TITLE
Refactor project to match dataset

### DIFF
--- a/backend/corpora/common/corpora_orm.py
+++ b/backend/corpora/common/corpora_orm.py
@@ -136,6 +136,9 @@ class DbUser(Base):
     created_at = Column(DateTime, nullable=False, server_default=DEFAULT_DATETIME)
     updated_at = Column(DateTime, nullable=False, server_default=DEFAULT_DATETIME)
 
+    # Relationships
+    projects = relationship("DbProject", back_populates="user")
+
 
 class DbProject(Base):
     """
@@ -158,8 +161,9 @@ class DbProject(Base):
     created_at = Column(DateTime(True), nullable=False, server_default=DEFAULT_DATETIME)
     updated_at = Column(DateTime(True), nullable=False, server_default=DEFAULT_DATETIME)
 
-    user = relationship("DbUser", uselist=False)
-    links = relationship("DbProjectLink")
+    # Relationships
+    user = relationship("DbUser", uselist=False, back_populates="projects")
+    links = relationship("DbProjectLink", back_populates="projects")
     datasets = relationship("DbDataset", secondary=lambda: DbProjectDataset().__table__, back_populates="project")
 
 
@@ -198,6 +202,9 @@ class DbProjectLink(Base):
     created_at = Column(DateTime(True), nullable=False, server_default=DEFAULT_DATETIME)
     updated_at = Column(DateTime(True), nullable=False, server_default=DEFAULT_DATETIME)
 
+    # Relationships
+    projects = relationship("DbProject", back_populates="links")
+
     # Composite FK
     __table_args__ = (ForeignKeyConstraint([project_id, project_status], [DbProject.id, DbProject.status]), {})
 
@@ -231,6 +238,7 @@ class DbDataset(Base):
     created_at = Column(DateTime, nullable=False, server_default=DEFAULT_DATETIME)
     updated_at = Column(DateTime, nullable=False, server_default=DEFAULT_DATETIME)
 
+    # Relationships
     project = relationship("DbProject", secondary=lambda: DbProjectDataset().__table__, back_populates="datasets")
     artifacts = relationship("DbDatasetArtifact", back_populates="dataset")
     deployment_directories = relationship("DbDeploymentDirectory", back_populates="dataset")
@@ -257,6 +265,7 @@ class DbDatasetArtifact(Base):
     created_at = Column(DateTime, nullable=False, server_default=DEFAULT_DATETIME)
     updated_at = Column(DateTime, nullable=False, server_default=DEFAULT_DATETIME)
 
+    # Relationships
     dataset = relationship("DbDataset", back_populates="artifacts")
 
 
@@ -275,6 +284,7 @@ class DbDeploymentDirectory(Base):
     created_at = Column(DateTime, nullable=False, server_default=DEFAULT_DATETIME)
     updated_at = Column(DateTime, nullable=False, server_default=DEFAULT_DATETIME)
 
+    # Relationships
     dataset = relationship("DbDataset", back_populates="deployment_directories")
 
 
@@ -291,6 +301,8 @@ class DbContributor(Base):
     email = Column(String)
     created_at = Column(DateTime, nullable=False, server_default=DEFAULT_DATETIME)
     updated_at = Column(DateTime, nullable=False, server_default=DEFAULT_DATETIME)
+
+    # Relationships
     datasets = relationship(
         "DbDataset", secondary=lambda: DbDatasetContributor().__table__, back_populates="contributors"
     )

--- a/backend/corpora/common/corpora_orm.py
+++ b/backend/corpora/common/corpora_orm.py
@@ -307,3 +307,6 @@ class DbDatasetContributor(Base):
     dataset_id = Column(ForeignKey("dataset.id"), nullable=False)
     created_at = Column(DateTime, nullable=False, server_default=DEFAULT_DATETIME)
     updated_at = Column(DateTime, nullable=False, server_default=DEFAULT_DATETIME)
+
+    contributor = relationship("DbContributor")
+    dataset = relationship("DbDataset", back_populates="contributors")

--- a/backend/corpora/common/corpora_orm.py
+++ b/backend/corpora/common/corpora_orm.py
@@ -310,6 +310,3 @@ class DbDatasetContributor(Base):
     dataset_id = Column(ForeignKey("dataset.id"), nullable=False)
     created_at = Column(DateTime, nullable=False, server_default=DEFAULT_DATETIME)
     updated_at = Column(DateTime, nullable=False, server_default=DEFAULT_DATETIME)
-
-    contributor = relationship("DbContributor")
-    dataset = relationship("DbDataset", back_populates="contributors")

--- a/backend/corpora/common/corpora_orm.py
+++ b/backend/corpora/common/corpora_orm.py
@@ -158,7 +158,9 @@ class DbProject(Base):
     created_at = Column(DateTime(True), nullable=False, server_default=DEFAULT_DATETIME)
     updated_at = Column(DateTime(True), nullable=False, server_default=DEFAULT_DATETIME)
 
-    user = relationship("DbUser")
+    user = relationship("DbUser", uselist=False)
+    links = relationship("DbProjectLink")
+    datasets = relationship("DbDataset", secondary=lambda: DbProjectDataset().__table__, back_populates="project")
 
 
 class DbProjectDataset(Base):
@@ -229,6 +231,7 @@ class DbDataset(Base):
     created_at = Column(DateTime, nullable=False, server_default=DEFAULT_DATETIME)
     updated_at = Column(DateTime, nullable=False, server_default=DEFAULT_DATETIME)
 
+    project = relationship("DbProject", secondary=lambda: DbProjectDataset().__table__, back_populates="datasets")
     artifacts = relationship("DbDatasetArtifact", back_populates="dataset")
     deployment_directories = relationship("DbDeploymentDirectory", back_populates="dataset")
     contributors = relationship(

--- a/backend/corpora/common/entities/dataset.py
+++ b/backend/corpora/common/entities/dataset.py
@@ -1,38 +1,9 @@
-import typing
-
 from .entity import Entity
 from ..corpora_orm import DbDataset
 
 
 class Dataset(Entity):
-    tables = [
-        DbDataset,
-    ]
+    table = DbDataset
 
     def __init__(self, db_object: DbDataset):
         super().__init__(db_object)
-
-    @classmethod
-    def _query(cls, key: str) -> typing.List["Dataset"]:
-        """
-        Given a key representing a dataset UUID, queries the database to return the associated dataset data.
-        :param key: dataset.id is the primary key.
-        :return: list of query result rows
-        """
-        result = cls.db.query(table_args=[DbDataset], filter_args=[key == DbDataset.id])
-        return result
-
-    @classmethod
-    def _load(cls, db_result: typing.List["Dataset"]) -> "Dataset":
-        """
-        Parses a database query result into a Dataset Entity instance.
-        :param db_result: list of query result rows
-        :return: Entity
-        """
-        try:
-            return cls(db_result[0])
-        except IndexError:
-            return None
-
-    def __getattr__(self, name):
-        return self.db_obj.__getattribute__(name)

--- a/backend/corpora/common/entities/dataset.py
+++ b/backend/corpora/common/entities/dataset.py
@@ -9,8 +9,8 @@ class Dataset(Entity):
         DbDataset,
     ]
 
-    def __init__(self, db_obj: DbDataset):
-        self.db_obj = db_obj
+    def __init__(self, db_object: DbDataset):
+        super().__init__(db_object)
 
     @classmethod
     def _query(cls, key: str) -> typing.List["Dataset"]:

--- a/backend/corpora/common/entities/entity.py
+++ b/backend/corpora/common/entities/entity.py
@@ -10,8 +10,8 @@ class Entity:
     database counterparts.
 
     This class uses a has-a relationship with SQLAlchemy Table object and simplify the CRUD operations performed on the
-    database through these objects. Columns and relationship of the database object can be access as attributes of the of
-    Entity.
+    database through these objects. Columns and relationship of the database object can be access as attributes of the
+    of Entity.
 
     Every application-level object must inherit Entity.
     Examples: Project, Dataset
@@ -45,8 +45,8 @@ class Entity:
         """
         Parses query result rows produced by Entity._query into an instantiated Entity object.
         The output of this function is the return value of Entity.get.
-        SQLAlchemy query results are stored in a list in which each item contains Table objects returned by the query. If no
-        results are found, None is returned.
+        SQLAlchemy query results are stored in a list in which each item contains Table objects returned by the query.
+        If no results are found, None is returned.
 
         Example query results access:
         row = query_results[0]

--- a/backend/corpora/common/entities/entity.py
+++ b/backend/corpora/common/entities/entity.py
@@ -55,6 +55,7 @@ class Entity:
         :param query_results: list of query result rows
         :return: Entity
         """
+
         try:
             return cls(db_result[0])
         except IndexError:

--- a/backend/corpora/common/entities/entity.py
+++ b/backend/corpora/common/entities/entity.py
@@ -10,7 +10,7 @@ class Entity:
     database counterparts.
 
     This class uses a has-a relationship with SQLAlchemy Table object and simplify the CRUD operations performed on the
-    database through these objects. Columns and relationship of the database object can be access as attributes of the
+    database through these objects. Columns and relationships of the database object can be access as attributes of the
     of Entity.
 
     Every application-level object must inherit Entity.

--- a/backend/corpora/common/entities/entity.py
+++ b/backend/corpora/common/entities/entity.py
@@ -9,6 +9,10 @@ class Entity:
     An abstract base class providing an interface to parse application-level objects to and from their
     database counterparts.
 
+    This class uses a has-a relationship with SQLAlchemy Table object and simplify the CRUD operations performed on the
+    database through these objects. Columns and relationship of the database object can be access as attributes of the of
+    Entity.
+
     Every application-level object must inherit Entity.
     Examples: Project, Dataset
     """
@@ -37,7 +41,19 @@ class Entity:
         raise NotImplementedError()
 
     @classmethod
-    def _load(cls, db_result: typing.List["Entity"]) -> "Entity":
+    def _load(cls, db_result: typing.List["Entity"]) -> typing.Union["Entity", None]:
+        """
+        Parses query result rows produced by Entity._query into an instantiated Entity object.
+        The output of this function is the return value of Entity.get.
+        SQLAlchemy query results are stored in a list in which each item contains Table objects returned by the query. If no
+        results are found, None is returned.
+
+        Example query results access:
+        row = query_results[0]
+        project_id = row.DbProject.id
+        :param query_results: list of query result rows
+        :return: Entity
+        """
         try:
             return cls(db_result[0])
         except IndexError:
@@ -59,4 +75,9 @@ class Entity:
         raise NotImplementedError()
 
     def __getattr__(self, name):
+        """
+        If the attribute is not in Entity, return the attribute in db_object.
+        :param name:
+        :return:
+        """
         return self.db_object.__getattribute__(name)

--- a/backend/corpora/common/entities/entity.py
+++ b/backend/corpora/common/entities/entity.py
@@ -15,6 +15,9 @@ class Entity:
 
     db = DbUtils()
 
+    def __init__(self, db_object: Base):
+        self.db_object = db_object
+
     @classmethod
     def get(cls, key: typing.Union[str, typing.Tuple[str, str]]):
         """
@@ -34,13 +37,11 @@ class Entity:
         raise NotImplementedError()
 
     @classmethod
-    def _load(cls, db_result: typing.List[Base]) -> "Entity":
-        """
-        Parses a database query result into an Entity instance
-        :param db_result: list of query result rows
-        :return: Entity
-        """
-        raise NotImplementedError()
+    def _load(cls, db_result: typing.List["Entity"]) -> "Entity":
+        try:
+            return cls(db_result[0])
+        except IndexError:
+            return None
 
     @classmethod
     def list(cls):
@@ -56,3 +57,6 @@ class Entity:
         :return: saved Entity object
         """
         raise NotImplementedError()
+
+    def __getattr__(self, name):
+        return self.db_object.__getattribute__(name)

--- a/backend/corpora/common/entities/entity.py
+++ b/backend/corpora/common/entities/entity.py
@@ -1,4 +1,7 @@
+import logging
 import typing
+
+logger = logging.getLogger(__name__)
 
 from ..corpora_orm import Base
 from ..utils.db_utils import DbUtils
@@ -17,48 +20,24 @@ class Entity:
     Examples: Project, Dataset
     """
 
+    table: Base = None  # The DbTable represented by this entity.
     db = DbUtils()
 
     def __init__(self, db_object: Base):
         self.db_object = db_object
 
     @classmethod
-    def get(cls, key: typing.Union[str, typing.Tuple[str, str]]):
+    def get(cls, key: typing.Union[str, typing.Tuple[str, str]]) -> typing.Union["Entity", None]:
         """
-        Retrieves an entity from the database given its primary key
+        Retrieves an entity from the database given its primary key if found.
         :param key: Simple or composite primary key
-        :return: Entity
+        :return: Entity or None
         """
-        return cls._load(cls._query(key))
-
-    @classmethod
-    def _query(cls, key: typing.Union[str, typing.Tuple[str, str]]) -> typing.List[Base]:
-        """
-        Queries the database for required entity data
-        :param key: Simple or composite primary key
-        :return: list of query result rows
-        """
-        raise NotImplementedError()
-
-    @classmethod
-    def _load(cls, db_result: typing.List["Entity"]) -> typing.Union["Entity", None]:
-        """
-
-        Parses query result rows produced by Entity._query into an instantiated Entity object.
-        The output of this function is the return value of Entity.get.
-        SQLAlchemy query results are stored in a list in which each item contains Table objects returned by the query.
-        If no results are found, None is returned.
-
-        Example query results access:
-        row = query_results[0]
-        project_id = row.DbProject.id
-        :param query_results: list of query result rows
-        :return: Entity
-        """
-
-        try:
-            return cls(db_result[0])
-        except IndexError:
+        result = cls.db.get(cls.table, key)
+        if result:
+            return cls(result)
+        else:
+            logger.info(f"Unable to find a row with primary key {key}, in {cls.__name__} table.")
             return None
 
     @classmethod

--- a/backend/corpora/common/entities/entity.py
+++ b/backend/corpora/common/entities/entity.py
@@ -43,6 +43,7 @@ class Entity:
     @classmethod
     def _load(cls, db_result: typing.List["Entity"]) -> typing.Union["Entity", None]:
         """
+
         Parses query result rows produced by Entity._query into an instantiated Entity object.
         The output of this function is the return value of Entity.get.
         SQLAlchemy query results are stored in a list in which each item contains Table objects returned by the query.

--- a/backend/corpora/common/entities/project.py
+++ b/backend/corpora/common/entities/project.py
@@ -1,56 +1,19 @@
-import copy
 import typing
 
+from .entity import Entity
 from ..corpora_orm import (
-    Base,
     DbProject,
-    DbProjectLink,
-    DbProjectDataset,
-    DbDatasetContributor,
-    DbContributor,
     ProjectStatus,
 )
-from .entity import Entity
 from ..utils.exceptions import CorporaException
 
 
 class Project(Entity):
-    def __init__(
-        self,
-        id: str,
-        status: str,
-        name: str = "",
-        description: str = "",
-        owner: str = "",
-        s3_bucket: str = "",
-        tc_uri: str = "",
-        needs_attestation: bool = False,
-        processing_state: str = "",
-        validation_state: str = "",
-        dataset_ids: list = None,
-        links: list = None,
-        contributors: list = None,
-        created_at: str = "",
-        updated_at: str = "",
-    ):
-        self.id = id
-        self.status = status
-        self.name = name
-        self.description = description
-        self.owner = owner
-        self.s3_bucket = s3_bucket
-        self.tc_uri = tc_uri
-        self.needs_attestation = needs_attestation
-        self.processing_state = processing_state
-        self.validation_state = validation_state
-        self.dataset_ids = dataset_ids
-        self.links = links
-        self.contributors = contributors
-        self.created_at = created_at
-        self.updated_at = updated_at
+    def __init__(self, db_object: DbProject):
+        super().__init__(db_object)
 
     @classmethod
-    def _query(cls, key: typing.Tuple[str, str]) -> typing.List[Base]:
+    def _query(cls, key: typing.Tuple[str, str]) -> typing.List[DbProject]:
         """
         Given a key, queries the database for a project and its relevant entities.
 
@@ -64,68 +27,6 @@ class Project(Entity):
         if key[1] not in statuses:
             raise CorporaException(f"Invalid status {key[1]}. Status must be one of {statuses}.")
 
-        result = cls.db.query(
-            table_args=[DbProject, DbProjectLink, DbProjectDataset, DbDatasetContributor, DbContributor],
-            filter_args=[
-                DbProject.id == key[0],
-                DbProject.status == key[1],
-                DbProject.id == DbProjectLink.project_id,
-                DbProject.status == DbProjectLink.project_status,
-                DbProject.id == DbProjectDataset.project_id,
-                DbProject.status == DbProjectDataset.project_status,
-                DbProjectDataset.dataset_id == DbDatasetContributor.dataset_id,
-                DbContributor.id == DbDatasetContributor.contributor_id,
-            ],
-        )
+        result = cls.db.query(table_args=[DbProject], filter_args=[DbProject.id == key[0], DbProject.status == key[1]],)
 
         return result
-
-    @classmethod
-    def _load(cls, query_results: typing.List[Base]) -> typing.Union["Project", None]:
-        """
-        Parses query result rows produced by Project._query into an instantiated Project object.
-        The output of this function is the return value of Entity.get.
-
-        SQLAlchemy query results are stored in a list in which each item contains Table objects
-        (Db* objects from corpora_orm.py) returned by the query.
-
-        Example query results access:
-        row = query_results[0]
-        project_id = row.DbProject.id
-
-        :param query_results: list of query result rows
-        :return: Project
-        """
-        if not query_results:
-            return None
-
-        # de-dupe peripheral entities from query results
-        dataset_ids = set()
-        links = {}
-        contributors = {}
-        for result in query_results:
-            dataset_ids.add(result.DbProjectDataset.dataset_id)
-
-            links[result.DbProjectLink.id] = {
-                "id": result.DbProjectLink.id,
-                "type": result.DbProjectLink.link_type,
-                "url": result.DbProjectLink.link_url,
-            }
-
-            contributors[result.DbContributor.id] = {
-                "id": result.DbContributor.id,
-                "name": result.DbContributor.name,
-                "institution": result.DbContributor.institution,
-                "email": result.DbContributor.email,
-            }
-
-        # build dict of Project parameters
-        project_params = copy.deepcopy(query_results[0].DbProject.__dict__)
-        # remove superfluous SQLAlchemy state field
-        project_params.pop("_sa_instance_state")
-        project_params["dataset_ids"] = list(dataset_ids)
-        project_params["links"] = list(links.values())
-        project_params["contributors"] = list(contributors.values())
-
-        # instantiate Project
-        return Project(**project_params)

--- a/backend/corpora/common/entities/project.py
+++ b/backend/corpora/common/entities/project.py
@@ -1,32 +1,9 @@
-import typing
-
 from .entity import Entity
-from ..corpora_orm import (
-    DbProject,
-    ProjectStatus,
-)
-from ..utils.exceptions import CorporaException
+from ..corpora_orm import DbProject
 
 
 class Project(Entity):
+    table = DbProject
+
     def __init__(self, db_object: DbProject):
         super().__init__(db_object)
-
-    @classmethod
-    def _query(cls, key: typing.Tuple[str, str]) -> typing.List[DbProject]:
-        """
-        Given a key, queries the database for a project and its relevant entities.
-
-        According to the Entity.get interface, the return value of this function is fed as the input to Project._load.
-
-        :param key: Composite primary key tuple of the form (project.id, project.status)
-        :return: list of SQLAlchemy query results
-        """
-        statuses = [status.name for status in ProjectStatus]
-
-        if key[1] not in statuses:
-            raise CorporaException(f"Invalid status {key[1]}. Status must be one of {statuses}.")
-
-        result = cls.db.query(table_args=[DbProject], filter_args=[DbProject.id == key[0], DbProject.status == key[1]],)
-
-        return result

--- a/tests/unit/backend/corpora/common/entities/test_project.py
+++ b/tests/unit/backend/corpora/common/entities/test_project.py
@@ -35,10 +35,4 @@ class TestProject(unittest.TestCase):
 
     def test__get__invalid_status(self):
         invalid_status_key = (self.uuid, "invalid_status")
-
-        with self.assertRaises(CorporaException) as context:
-            Project.get(invalid_status_key)
-
-        self.assertEqual(
-            "Invalid status invalid_status. Status must be one of ['LIVE', 'EDIT'].", str(context.exception)
-        )
+        self.assertEqual(Project.get(invalid_status_key), None)

--- a/tests/unit/backend/corpora/common/entities/test_project.py
+++ b/tests/unit/backend/corpora/common/entities/test_project.py
@@ -1,7 +1,7 @@
 import unittest
-from backend.corpora.common.entities.project import Project
-from backend.corpora.common.utils.exceptions import CorporaException
+
 from backend.corpora.common.corpora_orm import ProjectStatus, DbDataset, DbUser
+from backend.corpora.common.entities.project import Project
 
 
 class TestProject(unittest.TestCase):

--- a/tests/unit/backend/corpora/common/entities/test_project.py
+++ b/tests/unit/backend/corpora/common/entities/test_project.py
@@ -40,5 +40,3 @@ class TestProject(unittest.TestCase):
         with self.assertLogs(entity_logger, logging.INFO) as logs:
             self.assertEqual(Project.get(invalid_status_key), None)
         self.assertIn("Unable to find a row with primary key", logs.output[0])
-
-

--- a/tests/unit/backend/corpora/common/entities/test_project.py
+++ b/tests/unit/backend/corpora/common/entities/test_project.py
@@ -1,7 +1,7 @@
 import unittest
 from backend.corpora.common.entities.project import Project
 from backend.corpora.common.utils.exceptions import CorporaException
-from backend.corpora.common.corpora_orm import ProjectStatus
+from backend.corpora.common.corpora_orm import ProjectStatus, DbDataset, DbUser
 
 
 class TestProject(unittest.TestCase):
@@ -14,7 +14,19 @@ class TestProject(unittest.TestCase):
 
         project = Project.get(key)
 
+        # Verify Columns
         self.assertEqual(project.name, "test_project")
+        self.assertEqual(project.owner, "test_user_id")
+
+        # Verify User relationship
+        self.assertIsInstance(project.user, DbUser)
+        self.assertEqual(project.user.id, "test_user_id")
+
+        # Verify Dataset relationship
+        dataset = project.datasets[0]
+        self.assertIsInstance(dataset, DbDataset)
+        self.assertEqual(dataset.id, "test_dataset_id")
+        self.assertEqual(dataset.assay, "test_assay")
 
     def test__get__does_not_exist(self):
         non_existent_key = ("non_existent_id", self.status)

--- a/tests/unit/backend/corpora/common/entities/test_project.py
+++ b/tests/unit/backend/corpora/common/entities/test_project.py
@@ -1,6 +1,8 @@
+import logging
 import unittest
 
 from backend.corpora.common.corpora_orm import ProjectStatus, DbDataset, DbUser
+from backend.corpora.common.entities.entity import logger as entity_logger
 from backend.corpora.common.entities.project import Project
 
 
@@ -35,4 +37,8 @@ class TestProject(unittest.TestCase):
 
     def test__get__invalid_status(self):
         invalid_status_key = (self.uuid, "invalid_status")
-        self.assertEqual(Project.get(invalid_status_key), None)
+        with self.assertLogs(entity_logger, logging.INFO) as logs:
+            self.assertEqual(Project.get(invalid_status_key), None)
+        self.assertIn("Unable to find a row with primary key", logs.output[0])
+
+

--- a/tests/unit/backend/corpora/fixtures/database/__init__.py
+++ b/tests/unit/backend/corpora/fixtures/database/__init__.py
@@ -110,6 +110,12 @@ class TestDatabase:
         self.db.session.add(deployment_directory)
         self.db.session.commit()
 
+        deployment_directory = DbDeploymentDirectory(
+            id="test_deployment_directory_id", dataset_id=test_dataset_id, environment="test", url="test_url"
+        )
+        self.db.session.add(deployment_directory)
+        self.db.session.commit()
+
     def _create_test_dataset_artifacts(self):
         dataset_artifact = DbDatasetArtifact(
             id="test_dataset_artifact_id",

--- a/tests/unit/backend/corpora/fixtures/database/__init__.py
+++ b/tests/unit/backend/corpora/fixtures/database/__init__.py
@@ -110,12 +110,6 @@ class TestDatabase:
         self.db.session.add(deployment_directory)
         self.db.session.commit()
 
-        deployment_directory = DbDeploymentDirectory(
-            id="test_deployment_directory_id", dataset_id=test_dataset_id, environment="test", url="test_url"
-        )
-        self.db.session.add(deployment_directory)
-        self.db.session.commit()
-
     def _create_test_dataset_artifacts(self):
         dataset_artifact = DbDatasetArtifact(
             id="test_dataset_artifact_id",


### PR DESCRIPTION
By utilizing SQLAlchemy Object Relationship Mapping, CRUD operations will be easier to manage across the various tables.

- Adding more shared code to Entity
- Using SQLAlchemy relationships to query for values in other tables for DBProject
- Factoring out common code from Dataset