### PR TITLE
Add initial alembic migration framework.

### DIFF
--- a/backend/Makefile
+++ b/backend/Makefile
@@ -1,0 +1,39 @@
+db/migrate:
+	alembic -x db=${DEPLOYMENT_STAGE} -c=./config/database.ini upgrade head
+
+db/rollback:
+	alembic -x db=${DEPLOYMENT_STAGE}  -c=./config/database.ini downgrade -1
+
+db/new_migration:
+	# Usage: make db/new_migration MESSAGE="purpose_of_migration"
+	alembic -c=./config/database.ini revision --message $(MESSAGE)
+
+db/connect:
+	$(eval DATABASE_URI = $(shell aws secretsmanager get-secret-value --secret-id corpora/backend/${DEPLOYMENT_STAGE}/database --region us-east-1 | jq -r '.SecretString | fromjson.database_uri'))
+	psql --dbname $(DATABASE_URI)
+
+db/download:
+	# Usage: make db/download FROM=dev    - downloads DB to corpora_dev-<date>.sqlc
+	$(eval DATABASE_URI = $(shell aws secretsmanager get-secret-value --secret-id corpora/backend/${FROM}/database --region us-east-1 | jq -r '.SecretString | fromjson.database_uri'))
+	$(eval OUTFILE = $(shell date +corpora_${FROM}-%Y%m%d%H%M.sqlc))
+	pg_dump -Fc --dbname=$(DATABASE_URI) --file=$(OUTFILE)
+
+db/import:
+	# Usage: make db/import FROM=dev    - imports corpora_dev.sqlc into corpora_local
+	pg_restore --clean --no-owner --dbname corpora_local corpora_$(FROM).sqlc
+
+db/import/schema:
+	# Usage: DEPLOYMENT_STAGE=dev make db/import/schema  - imports corpora_dev.sqlc into corpora_local
+	pg_restore --schema-only --clean --no-owner --dbname corpora_local corpora_$(DEPLOYMENT_STAGE).sqlc
+	# Also import alembic schema version
+	pg_restore --data-only --table=alembic_version --no-owner --dbname corpora_local corpora_$(DEPLOYMENT_STAGE).sqlc
+
+db/dump_schema:
+	pg_dump --schema-only --dbname=corpora_local
+
+db/test_migration:
+	$(MAKE) db/dump_schema > /tmp/before
+	$(MAKE) db/migrate
+	$(MAKE) db/rollback
+	$(MAKE) db/dump_schema > /tmp/after
+	diff /tmp/{before,after} # No news is good news.

--- a/backend/Makefile
+++ b/backend/Makefile
@@ -13,17 +13,20 @@ db/connect:
 	psql --dbname $(DATABASE_URI)
 
 db/download:
-	# Usage: make db/download FROM=dev    - downloads DB to corpora_dev-<date>.sqlc
+    # Download the database to corpora_dev-<date>.sqlc
+	# Usage: make db/download FROM=dev
 	$(eval DATABASE_URI = $(shell aws secretsmanager get-secret-value --secret-id corpora/backend/${FROM}/database --region us-east-1 | jq -r '.SecretString | fromjson.database_uri'))
 	$(eval OUTFILE = $(shell date +corpora_${FROM}-%Y%m%d%H%M.sqlc))
 	pg_dump -Fc --dbname=$(DATABASE_URI) --file=$(OUTFILE)
 
 db/import:
-	# Usage: make db/import FROM=dev    - imports corpora_dev.sqlc into corpora_local
+    # Imports corpora_dev.sqlc into the corpora_local database
+	# Usage: make db/import FROM=dev
 	pg_restore --clean --no-owner --dbname corpora_local corpora_$(FROM).sqlc
 
 db/import/schema:
-	# Usage: DEPLOYMENT_STAGE=dev make db/import/schema  - imports corpora_dev.sqlc into corpora_local
+    # Imports the corpora_dev.sqlc schema (schema ONLY) into the corpora_local database
+	# Usage: DEPLOYMENT_STAGE=dev make db/import/schema
 	pg_restore --schema-only --clean --no-owner --dbname corpora_local corpora_$(DEPLOYMENT_STAGE).sqlc
 	# Also import alembic schema version
 	pg_restore --data-only --table=alembic_version --no-owner --dbname corpora_local corpora_$(DEPLOYMENT_STAGE).sqlc

--- a/backend/config/database.ini
+++ b/backend/config/database.ini
@@ -1,0 +1,89 @@
+# A generic, single database configuration.
+
+[alembic]
+# path to migration scripts
+script_location = alembic
+
+# template used to generate migration files
+# file_template = %%(rev)s_%%(slug)s
+
+# timezone to use when rendering the date
+# within the migration file as well as the filename.
+# string value is passed to dateutil.tz.gettz()
+# leave blank for localtime
+# timezone =
+
+# max length of characters to apply to the
+# "slug" field
+# truncate_slug_length = 40
+
+# set to 'true' to run the environment during
+# the 'revision' command, regardless of autogenerate
+# revision_environment = false
+
+# set to 'true' to allow .pyc and .pyo files without
+# a source .py file to be detected as revisions in the
+# versions/ directory
+# sourceless = false
+
+# version location specification; this defaults
+# to database/versions.  When using multiple version
+# directories, initial revisions must be specified with --version-path
+# version_locations = %(here)s/bar %(here)s/bat database/versions
+
+# the output encoding used when revision files
+# are written from script.py.mako
+# output_encoding = utf-8
+
+[dev]
+sqlalchemy.url =
+
+[staging]
+sqlalchemy.url =
+
+
+[post_write_hooks]
+# post_write_hooks defines scripts or Python functions that are run
+# on newly generated revision scripts.  See the documentation for further
+# detail and examples
+
+# format using "black" - use the console_scripts runner, against the "black" entrypoint
+# hooks=black
+# black.type=console_scripts
+# black.entrypoint=black
+# black.options=-l 79
+
+# Logging configuration
+[loggers]
+keys = root,sqlalchemy,alembic
+
+[handlers]
+keys = console
+
+[formatters]
+keys = generic
+
+[logger_root]
+level = WARN
+handlers = console
+qualname =
+
+[logger_sqlalchemy]
+level = WARN
+handlers =
+qualname = sqlalchemy.engine
+
+[logger_alembic]
+level = INFO
+handlers =
+qualname = alembic
+
+[handler_console]
+class = StreamHandler
+args = (sys.stderr,)
+level = NOTSET
+formatter = generic
+
+[formatter_generic]
+format = %(levelname)-5.5s [%(name)s] %(message)s
+datefmt = %H:%M:%S

--- a/backend/database/README
+++ b/backend/database/README
@@ -1,0 +1,1 @@
+Generic single-database configuration.

--- a/backend/database/env.py
+++ b/backend/database/env.py
@@ -1,0 +1,89 @@
+import os
+from logging.config import fileConfig
+
+from alembic import context
+from sqlalchemy import engine_from_config, pool
+
+from ..corpora.common.corpora_config import CorporaDbConfig
+
+# this is the Alembic Config object, which provides access to the values within the .ini file in use.
+config = context.config
+
+# Interpret the config file for Python logging.
+# This line sets up loggers basically.
+fileConfig(config.config_file_name)
+
+# add your model's MetaData object here
+# for 'autogenerate' support
+# from myapp import mymodel
+# target_metadata = mymodel.Base.metadata
+target_metadata = None
+
+# other values from the config, defined by the needs of env.py, can be acquired:
+# my_important_option = config.get_main_option("my_important_option")
+# ... etc.
+
+# Get the arguments passed in after running `alembic -x ...` to get the database's deployment stage.
+command_line_arguments = context.get_x_argument(as_dictionary=True)
+if "db" not in command_line_arguments:
+    raise Exception(
+        "We couldn't find `db` in the CLI argument when the `alembic -x` command was run. Please verify that the "
+        "command was run as `alembic -x db=<db_name>` (e.g. `alembic -x db=dev upgrade head`)."
+    )
+database_deployment_stage = command_line_arguments["db"]
+
+
+def run_migrations_offline():
+    """
+    Run migrations in 'offline' mode.
+
+    This configures the context with just a URL and not an Engine, though an Engine is acceptable here as well.  By
+    skipping the Engine creation we don't even need a DBAPI to be available.
+
+    Calls to context.execute() here emit the given string to the script output.
+    """
+
+    url = config.get_main_option("sqlalchemy.url")
+    context.configure(
+        url=url, target_metadata=target_metadata, literal_binds=True, dialect_opts={"paramstyle": "named"},
+    )
+
+    with context.begin_transaction():
+        context.run_migrations()
+
+
+def run_migrations_online():
+    """
+    Run migrations in 'online' mode.
+
+    In this scenario we need to create an Engine and associate a connection with the context. We override the alembic
+    config with the CorporaDbConfig information.
+    """
+
+    alembic_config = config.get_section(config.config_ini_section)
+    db_config = config.get_section(database_deployment_stage)
+
+    for key in db_config:
+        alembic_config[key] = db_config[key]
+
+    if os.environ["DEPLOYMENT_STAGE"] != database_deployment_stage:
+        raise Exception(
+            f"Deployment stage OS environ variable: {os.environ['DEPLOYMENT_STAGE']} and db deployment "
+            f"stage specified through `db` argument: {database_deployment_stage} are different!"
+        )
+
+    alembic_config["sqlalchemy.url"] = CorporaDbConfig().database_uri
+
+    connectable = engine_from_config(alembic_config, prefix="sqlalchemy.", poolclass=pool.NullPool)
+
+    with connectable.connect() as connection:
+        context.configure(connection=connection, target_metadata=target_metadata)
+
+        with context.begin_transaction():
+            context.run_migrations()
+
+
+if context.is_offline_mode():
+    run_migrations_offline()
+else:
+    run_migrations_online()

--- a/backend/database/env.py
+++ b/backend/database/env.py
@@ -44,9 +44,7 @@ def run_migrations_offline():
     """
 
     url = config.get_main_option("sqlalchemy.url")
-    context.configure(
-        url=url, target_metadata=target_metadata, literal_binds=True, dialect_opts={"paramstyle": "named"},
-    )
+    context.configure(url=url, target_metadata=target_metadata, literal_binds=True)
 
     with context.begin_transaction():
         context.run_migrations()

--- a/backend/database/script.py.mako
+++ b/backend/database/script.py.mako
@@ -1,0 +1,24 @@
+"""${message}
+
+Revision ID: ${up_revision}
+Revises: ${down_revision | comma,n}
+Create Date: ${create_date}
+
+"""
+from alembic import op
+import sqlalchemy as sa
+${imports if imports else ""}
+
+# revision identifiers, used by Alembic.
+revision = ${repr(up_revision)}
+down_revision = ${repr(down_revision)}
+branch_labels = ${repr(branch_labels)}
+depends_on = ${repr(depends_on)}
+
+
+def upgrade():
+    ${upgrades if upgrades else "pass"}
+
+
+def downgrade():
+    ${downgrades if downgrades else "pass"}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+alembic
 anndata
 black
 botocore>=1.14.17


### PR DESCRIPTION
Couple notes: much of this code is generated by running `alembic init alembic` and I left most of it as is except for a few formatting things that black decided to change. The main changes here are the `run_migrations_online` function in `env.py` and the scripts for migration which were pulled from the original dcp 2.0 code (which were pulled from upload-service). They provide some nice sugar around being able to execute migrations cleanly.

One thing I'd love to get feedback on is the location of the files. Currently I renamed the `alembic` directory that was created to `database` to more clearly elucidate what the contents are related to and I put the `database.ini` file in the config directory (it was floating in the top level `backend` directory when originally generated). The Makefile with all the database-related commands are in the top-level `backend` directory since they make use of `database/` and `config/` directories. I am open to other arrangements though if the above doesn't make sense. 