### PR TITLE
Responsible session management.

### DIFF
--- a/backend/corpora/common/entities/dataset.py
+++ b/backend/corpora/common/entities/dataset.py
@@ -38,6 +38,8 @@ class Dataset(Entity):
         """
         Creates a new dataset and related objects and store in the database. UUIDs are generated for all new table
         entries.
+
+        :param session: an open session to the database
         """
         primary_key = str(uuid.uuid4())
 

--- a/backend/corpora/common/entities/entity.py
+++ b/backend/corpora/common/entities/entity.py
@@ -31,6 +31,8 @@ class Entity:
     def get(cls, session, key: typing.Union[str, typing.Tuple[str, str]]) -> typing.Union["Entity", None]:
         """
         Retrieves an entity from the database given its primary key if found.
+
+        :param session: an open session to the database
         :param key: Simple or composite primary key
         :return: Entity or None
         """
@@ -76,6 +78,7 @@ class Entity:
         Create or modify `rows` in `db_table` associated with Entity Object during object creation. If id is provided,
         then the row with that id is retrieved and updated, else a new UUID is generated and a new row is created.
 
+        :param session: an open session to the database
         :param rows: A list of dictionaries each specifying a row to insert or modify
         :param db_table: The Table to add or modify rows
         :param primary_keys: Additional columns required to build the primary key. This is used when the primary consist

--- a/backend/corpora/common/entities/entity.py
+++ b/backend/corpora/common/entities/entity.py
@@ -5,7 +5,7 @@ import uuid
 logger = logging.getLogger(__name__)
 
 from ..corpora_orm import Base
-from ..utils.db_utils import DbUtils
+from ..utils.db_utils import get
 
 
 class Entity:
@@ -22,21 +22,21 @@ class Entity:
     """
 
     table: Base = None  # The DbTable represented by this entity.
-    db = DbUtils()
 
-    def __init__(self, db_object: Base):
+    def __init__(self, session, db_object: Base):
+        self.session = session
         self.db_object = db_object
 
     @classmethod
-    def get(cls, key: typing.Union[str, typing.Tuple[str, str]]) -> typing.Union["Entity", None]:
+    def get(cls, session, key: typing.Union[str, typing.Tuple[str, str]]) -> typing.Union["Entity", None]:
         """
         Retrieves an entity from the database given its primary key if found.
         :param key: Simple or composite primary key
         :return: Entity or None
         """
-        result = cls.db.get(cls.table, key)
+        result = get(session, cls.table, key)
         if result:
-            return cls(result)
+            return cls(session, result)
         else:
             logger.info(f"Unable to find a row with primary key {key}, in {cls.__name__} table.")
             return None
@@ -65,7 +65,12 @@ class Entity:
 
     @classmethod
     def _create_sub_objects(
-        cls, rows: typing.List[dict], db_table: Base, add_columns: dict = None, primary_keys: typing.List[str] = None
+        cls,
+        session,
+        rows: typing.List[dict],
+        db_table: Base,
+        add_columns: dict = None,
+        primary_keys: typing.List[str] = None,
     ) -> typing.List[Base]:
         """
         Create or modify `rows` in `db_table` associated with Entity Object during object creation. If id is provided,
@@ -80,7 +85,9 @@ class Entity:
         This can be used when there are shared column values that need to be added across all the new rows.
         For example: DbProjectLink generated for a specific project should all have the same DbProjectLink.project_id
         and DbProjectLink.project_status. The function call would be:
+        >>>> session = DBSessionMaker().session()
         >>>> cls._create_sub_objects(
+        >>>>    session,
         >>>>    [{'link_url':'abc', 'link_type': ProjectLinkType.OTHER}],
         >>>>    DbProjectLink,
         >>>>    add_columns={'project_id':'abcd','project_status':ProjectStatus.EDIT}
@@ -98,7 +105,7 @@ class Entity:
             _id = _columns.get("id")
             if _id:
                 primary_key = (_id, *primary_keys) if primary_keys else _id
-                row = cls.db.get(db_table, primary_key)
+                row = get(session, db_table, primary_key)
             else:
                 _columns["id"] = str(uuid.uuid4())
                 row = db_table(**_columns)

--- a/backend/corpora/common/entities/project.py
+++ b/backend/corpora/common/entities/project.py
@@ -7,12 +7,13 @@ from ..corpora_orm import DbProject, DbProjectLink
 class Project(Entity):
     table = DbProject
 
-    def __init__(self, db_object: DbProject):
-        super().__init__(db_object)
+    def __init__(self, session, db_object: DbProject):
+        super().__init__(session, db_object)
 
     @classmethod
     def create(
         cls,
+        session,
         status: str,
         name: str = "",
         description: str = "",
@@ -50,10 +51,10 @@ class Project(Entity):
             processing_state=processing_state,
             validation_state=validation_state,
             links=cls._create_sub_objects(
-                links, DbProjectLink, add_columns=dict(project_id=primary_key, project_status=status, **kwargs)
+                session, links, DbProjectLink, add_columns=dict(project_id=primary_key, project_status=status, **kwargs)
             ),
         )
 
-        cls.db.session.add(new_db_object)
-        cls.db.commit()
-        return cls(new_db_object)
+        session.add(new_db_object)
+        session.commit()
+        return cls(session, new_db_object)

--- a/backend/corpora/common/entities/project.py
+++ b/backend/corpora/common/entities/project.py
@@ -29,6 +29,8 @@ class Project(Entity):
         """
         Create a new Project and related objects and store in the database. UUIDs are generated for all new table
         entries.
+
+        :param session: an open session to the database
         """
         primary_key = str(uuid.uuid4())
 

--- a/backend/corpora/common/utils/db_utils.py
+++ b/backend/corpora/common/utils/db_utils.py
@@ -19,11 +19,6 @@ def session_scope():
     try:
         yield session
         logger.info("Commit database changes.")
-        session.commit()
-    except SQLAlchemyError:
-        session.rollback()
-        logger.exception(COMMIT_ERROR_MSG)
-        raise CorporaException(COMMIT_ERROR_MSG)
     finally:
         logger.info("Closing database session.")
         session.close()

--- a/backend/corpora/common/utils/db_utils.py
+++ b/backend/corpora/common/utils/db_utils.py
@@ -1,17 +1,38 @@
 import logging
 import typing
+from contextlib import contextmanager
 
 from sqlalchemy.exc import SQLAlchemyError
 
 from .exceptions import CorporaException
-from ..corpora_orm import Base
+from ..corpora_orm import Base, DBSessionMaker
 
 logger = logging.getLogger(__name__)
+
+COMMIT_ERROR_MSG = "Failed to commit."
+
+
+@contextmanager
+def session_scope():
+    """Database Sessions context manager"""
+    session = DBSessionMaker().session()
+    try:
+        yield session
+        logger.info("Commit database changes.")
+        session.commit()
+    except SQLAlchemyError:
+        session.rollback()
+        logger.exception(COMMIT_ERROR_MSG)
+        raise CorporaException(COMMIT_ERROR_MSG)
+    finally:
+        logger.info("Closing database session.")
+        session.close()
 
 
 def get(session, table: Base, entity_id: typing.Union[str, typing.Tuple[str]]) -> typing.Union[Base, None]:
     """
     Query a table row by its primary key
+    :param session: an open session to the database
     :param table: SQLAlchemy Table to query
     :param entity_id: Primary key of desired row
     :return: SQLAlchemy Table object, None if not found
@@ -22,6 +43,7 @@ def get(session, table: Base, entity_id: typing.Union[str, typing.Tuple[str]]) -
 def query(session, table_args: typing.List[Base], filter_args: typing.List[bool] = None) -> typing.List[Base]:
     """
     Query the database using the current DB session
+    :param session: an open session to the database
     :param table_args: List of SQLAlchemy Tables to query/join
     :param filter_args: List of SQLAlchemy filter conditions
     :return: List of SQLAlchemy query response objects
@@ -32,11 +54,12 @@ def query(session, table_args: typing.List[Base], filter_args: typing.List[bool]
 def commit(session):
     """
     Commit changes to the database and roll back if error.
+
+    :param session: an open session to the database
     """
     try:
         session.commit()
     except SQLAlchemyError:
         session.rollback()
-        msg = "Failed to commit."
-        logger.exception(msg)
-        raise CorporaException(msg)
+        logger.exception(COMMIT_ERROR_MSG)
+        raise CorporaException(COMMIT_ERROR_MSG)

--- a/backend/corpora/common/utils/db_utils.py
+++ b/backend/corpora/common/utils/db_utils.py
@@ -1,48 +1,42 @@
-import typing
 import logging
+import typing
 
 from sqlalchemy.exc import SQLAlchemyError
+
 from .exceptions import CorporaException
-from ..corpora_orm import Base, DBSessionMaker
+from ..corpora_orm import Base
 
 logger = logging.getLogger(__name__)
 
 
-class DbUtils:
-    def __init__(self):
-        self.session = DBSessionMaker().session()
-        self.engine = self.session.get_bind()
+def get(session, table: Base, entity_id: typing.Union[str, typing.Tuple[str]]) -> typing.Union[Base, None]:
+    """
+    Query a table row by its primary key
+    :param table: SQLAlchemy Table to query
+    :param entity_id: Primary key of desired row
+    :return: SQLAlchemy Table object, None if not found
+    """
+    return session.query(table).get(entity_id)
 
-    def get(self, table: Base, entity_id: typing.Union[str, typing.Tuple[str]]) -> typing.Union[Base, None]:
-        """
-        Query a table row by its primary key
-        :param table: SQLAlchemy Table to query
-        :param entity_id: Primary key of desired row
-        :return: SQLAlchemy Table object, None if not found
-        """
-        return self.session.query(table).get(entity_id)
 
-    def query(self, table_args: typing.List[Base], filter_args: typing.List[bool] = None) -> typing.List[Base]:
-        """
-        Query the database using the current DB session
-        :param table_args: List of SQLAlchemy Tables to query/join
-        :param filter_args: List of SQLAlchemy filter conditions
-        :return: List of SQLAlchemy query response objects
-        """
-        return (
-            self.session.query(*table_args).filter(*filter_args).all()
-            if filter_args
-            else self.session.query(*table_args).all()
-        )
+def query(session, table_args: typing.List[Base], filter_args: typing.List[bool] = None) -> typing.List[Base]:
+    """
+    Query the database using the current DB session
+    :param table_args: List of SQLAlchemy Tables to query/join
+    :param filter_args: List of SQLAlchemy filter conditions
+    :return: List of SQLAlchemy query response objects
+    """
+    return session.query(*table_args).filter(*filter_args).all() if filter_args else session.query(*table_args).all()
 
-    def commit(self):
-        """
-        Commit changes to the database and roll back if error.
-        """
-        try:
-            self.session.commit()
-        except SQLAlchemyError:
-            self.session.rollback()
-            msg = "Failed to commit."
-            logger.exception(msg)
-            raise CorporaException(msg)
+
+def commit(session):
+    """
+    Commit changes to the database and roll back if error.
+    """
+    try:
+        session.commit()
+    except SQLAlchemyError:
+        session.rollback()
+        msg = "Failed to commit."
+        logger.exception(msg)
+        raise CorporaException(msg)

--- a/tests/unit/backend/corpora/fixtures/database/__init__.py
+++ b/tests/unit/backend/corpora/fixtures/database/__init__.py
@@ -5,7 +5,7 @@ pkg_root = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", "
 sys.path.insert(0, pkg_root)  # noqa
 
 from backend.scripts.create_db import create_db
-from backend.corpora.common.utils.db_utils import DbUtils
+from backend.corpora.common.utils.db_utils import session_scope
 from backend.corpora.common.corpora_orm import (
     ProjectStatus,
     ProcessingState,
@@ -28,9 +28,9 @@ from backend.corpora.common.corpora_orm import (
 class TestDatabase:
     def __init__(self):
         create_db()
-        self.db = DbUtils()
-        self._populate_test_data()
-        del self.db
+        with session_scope() as session:
+            self.session = session
+            self._populate_test_data()
 
     def _populate_test_data(self):
         self._create_test_users()
@@ -42,8 +42,8 @@ class TestDatabase:
 
     def _create_test_users(self):
         user = DbUser(id="test_user_id", name="test_user", email="test_email")
-        self.db.session.add(user)
-        self.db.session.commit()
+        self.session.add(user)
+        self.session.commit()
 
     def _create_test_projects(self):
         project = DbProject(
@@ -58,8 +58,8 @@ class TestDatabase:
             processing_state=ProcessingState.NA.name,
             validation_state=ValidationState.NOT_VALIDATED.name,
         )
-        self.db.session.add(project)
-        self.db.session.commit()
+        self.session.add(project)
+        self.session.commit()
 
     def _create_test_project_links(self):
         project_link = DbProjectLink(
@@ -69,8 +69,8 @@ class TestDatabase:
             link_url="test_url",
             link_type=ProjectLinkType.RAW_DATA.name,
         )
-        self.db.session.add(project_link)
-        self.db.session.commit()
+        self.session.add(project_link)
+        self.session.commit()
 
     def _create_test_datasets(self):
         test_dataset_id = "test_dataset_id"
@@ -93,8 +93,8 @@ class TestDatabase:
             preprint_doi="test_preprint_doi",
             publication_doi="test_publication_doi",
         )
-        self.db.session.add(dataset)
-        self.db.session.commit()
+        self.session.add(dataset)
+        self.session.commit()
 
         project_dataset = DbProjectDataset(
             id="test_project_dataset_id",
@@ -102,13 +102,13 @@ class TestDatabase:
             project_status=ProjectStatus.LIVE.name,
             dataset_id=test_dataset_id,
         )
-        self.db.session.add(project_dataset)
+        self.session.add(project_dataset)
 
         deployment_directory = DbDeploymentDirectory(
             id="test_deployment_directory_id", dataset_id=test_dataset_id, environment="test", url="test_url"
         )
-        self.db.session.add(deployment_directory)
-        self.db.session.commit()
+        self.session.add(deployment_directory)
+        self.session.commit()
 
     def _create_test_dataset_artifacts(self):
         dataset_artifact = DbDatasetArtifact(
@@ -120,18 +120,18 @@ class TestDatabase:
             user_submitted=True,
             s3_uri="test_s3_uri",
         )
-        self.db.session.add(dataset_artifact)
-        self.db.session.commit()
+        self.session.add(dataset_artifact)
+        self.session.commit()
 
     def _create_test_contributors(self):
         contributor = DbContributor(
             id="test_contributor_id", name="test_contributor_name", institution="test_institution", email="test_email"
         )
-        self.db.session.add(contributor)
-        self.db.session.commit()
+        self.session.add(contributor)
+        self.session.commit()
 
         dataset_contributor = DbDatasetContributor(
             id="test_dataset_contributor_id", contributor_id="test_contributor_id", dataset_id="test_dataset_id"
         )
-        self.db.session.add(dataset_contributor)
-        self.db.session.commit()
+        self.session.add(dataset_contributor)
+        self.session.commit()


### PR DESCRIPTION
Before we were leaving the session open and never closing it. This was only a problem during testing where both the chalice application and the test code were using the same session. This corrects this by instantiating a session object for every database operation involving an Entity.