### PR TITLE
Cascade update and delete of row in the database

### DIFF
--- a/backend/corpora/common/corpora_orm.py
+++ b/backend/corpora/common/corpora_orm.py
@@ -198,8 +198,8 @@ class DbProject(Base):
 
     # Relationships
     user = relationship("DbUser", uselist=False, back_populates="projects")
-    links = relationship("DbProjectLink", back_populates="project")
-    datasets = relationship("DbDataset", back_populates="project")
+    links = relationship("DbProjectLink", back_populates="project", cascade="all, delete-orphan")
+    datasets = relationship("DbDataset", back_populates="project", cascade="all, delete-orphan")
 
 
 class DbProjectLink(Base):
@@ -260,10 +260,12 @@ class DbDataset(Base):
 
     # Relationships
     project = relationship("DbProject", uselist=False, back_populates="datasets")
-    artifacts = relationship("DbDatasetArtifact", back_populates="dataset")
-    deployment_directories = relationship("DbDeploymentDirectory", back_populates="dataset")
+    artifacts = relationship("DbDatasetArtifact", back_populates="dataset", cascade="all, delete-orphan")
+    deployment_directories = relationship(
+        "DbDeploymentDirectory", back_populates="dataset", cascade="all, delete-orphan"
+    )
     contributors = relationship(
-        "DbContributor", secondary=lambda: DbDatasetContributor().__table__, back_populates="datasets"
+        "DbContributor", secondary=lambda: DbDatasetContributor().__table__, back_populates="datasets",
     )
 
     # Composite FK

--- a/backend/corpora/common/entities/dataset.py
+++ b/backend/corpora/common/entities/dataset.py
@@ -84,3 +84,14 @@ class Dataset(Entity):
         cls.db.commit()
 
         return cls(new_db_object)
+
+    def delete(self):
+        """
+        Delete the Dataset and all child objects. Contributors connect to a dataset are deleted if they are not longer
+        connected to any datasets.
+        """
+        contributors = self.db_object.contributors
+        for contributor in contributors:
+            if len(contributor.datasets) == 1:
+                self.db.delete(contributor)
+        super().delete()

--- a/backend/corpora/common/entities/entity.py
+++ b/backend/corpora/common/entities/entity.py
@@ -100,3 +100,10 @@ class Entity:
             row = db_table(**_columns)
             db_objs.append(row)
         return db_objs
+
+    def delete(self):
+        """
+        Delete an object from the database.
+        """
+        self.db.delete(self.db_object)
+        self.db.commit()

--- a/backend/corpora/common/utils/db_utils.py
+++ b/backend/corpora/common/utils/db_utils.py
@@ -9,40 +9,55 @@ logger = logging.getLogger(__name__)
 
 
 class DbUtils:
+    """DbUtils as a singleton to avoid creating excess sessions."""
+
+    __instance = None
+
+    class __DbUtils:
+        def __init__(self):
+            self.session = DBSessionMaker().session()
+            self.engine = self.session.get_bind()
+
+        def get(self, table: Base, entity_id: typing.Union[str, typing.Tuple[str]]) -> typing.Union[Base, None]:
+            """
+            Query a table row by its primary key
+            :param table: SQLAlchemy Table to query
+            :param entity_id: Primary key of desired row
+            :return: SQLAlchemy Table object, None if not found
+            """
+            return self.session.query(table).get(entity_id)
+
+        def query(self, table_args: typing.List[Base], filter_args: typing.List[bool] = None) -> typing.List[Base]:
+            """
+            Query the database using the current DB session
+            :param table_args: List of SQLAlchemy Tables to query/join
+            :param filter_args: List of SQLAlchemy filter conditions
+            :return: List of SQLAlchemy query response objects
+            """
+            return (
+                self.session.query(*table_args).filter(*filter_args).all()
+                if filter_args
+                else self.session.query(*table_args).all()
+            )
+
+        def commit(self):
+            """
+            Commit changes to the database and roll back if error.
+            """
+            try:
+                self.session.commit()
+            except SQLAlchemyError:
+                self.session.rollback()
+                msg = "Failed to commit."
+                logger.exception(msg)
+                raise CorporaException(msg)
+
+        def delete(self, db_object: Base):
+            self.session.delete(db_object)
+
     def __init__(self):
-        self.session = DBSessionMaker().session()
-        self.engine = self.session.get_bind()
+        if not DbUtils.__instance:
+            DbUtils.__instance = DbUtils.__DbUtils()
 
-    def get(self, table: Base, entity_id: typing.Union[str, typing.Tuple[str]]) -> typing.Union[Base, None]:
-        """
-        Query a table row by its primary key
-        :param table: SQLAlchemy Table to query
-        :param entity_id: Primary key of desired row
-        :return: SQLAlchemy Table object, None if not found
-        """
-        return self.session.query(table).get(entity_id)
-
-    def query(self, table_args: typing.List[Base], filter_args: typing.List[bool] = None) -> typing.List[Base]:
-        """
-        Query the database using the current DB session
-        :param table_args: List of SQLAlchemy Tables to query/join
-        :param filter_args: List of SQLAlchemy filter conditions
-        :return: List of SQLAlchemy query response objects
-        """
-        return (
-            self.session.query(*table_args).filter(*filter_args).all()
-            if filter_args
-            else self.session.query(*table_args).all()
-        )
-
-    def commit(self):
-        """
-        Commit changes to the database and roll back if error.
-        """
-        try:
-            self.session.commit()
-        except SQLAlchemyError:
-            self.session.rollback()
-            msg = "Failed to commit."
-            logger.exception(msg)
-            raise CorporaException(msg)
+    def __getattr__(self, name):
+        return getattr(self.__instance, name)

--- a/tests/unit/backend/corpora/common/entities/test_dataset.py
+++ b/tests/unit/backend/corpora/common/entities/test_dataset.py
@@ -1,3 +1,4 @@
+import typing
 import unittest
 
 from backend.corpora.common.corpora_orm import (
@@ -7,32 +8,13 @@ from backend.corpora.common.corpora_orm import (
     DatasetArtifactType,
     DatasetArtifactFileType,
     ProjectStatus,
+    DbDataset,
+    DbProject,
+    Base,
 )
 from backend.corpora.common.entities.dataset import Dataset
-
-
-class BogusDatasetParams:
-    @classmethod
-    def get(cls):
-        return dict(
-            name="create_dataset",
-            organism="organism",
-            organism_ontology="123",
-            tissue="tissue",
-            tissue_ontology="123",
-            assay="assay",
-            assay_ontology="123",
-            disease="diseas",
-            disease_ontology="123",
-            sex="F",
-            ethnicity="ethnicity",
-            ethnicity_ontology="123",
-            source_data_location="location",
-            preprint_doi="preprint",
-            publication_doi="publication",
-            project_id="test_project_id",
-            project_status=ProjectStatus.LIVE.name,
-        )
+from backend.corpora.common.utils.db_utils import DbUtils
+from unit.backend.utils import BogusDatasetParams
 
 
 class TestDataset(unittest.TestCase):
@@ -88,21 +70,98 @@ class TestDataset(unittest.TestCase):
                 )
 
                 expected_dataset_id = dataset.id
-                expected_artifacts = dataset.artifacts
-                expected_deployment_directories = dataset.deployment_directories
-                expected_contributors = dataset.contributors
+                expected_artifacts = [art.to_dict() for art in dataset.artifacts]
+                expected_deployment_directories = [dep.to_dict() for dep in dataset.deployment_directories]
+                expected_contributors = [con.to_dict() for con in dataset.contributors]
 
                 # Expire all local objects and retrieve them from the DB to make sure the transactions went through.
                 Dataset.db.session.expire_all()
 
                 actual_dataset = Dataset.get(expected_dataset_id)
+                actual_artifacts = [art.to_dict() for art in actual_dataset.artifacts]
+                actual_deployment_directories = [dep.to_dict() for dep in actual_dataset.deployment_directories]
+                actual_contributors = [con.to_dict() for con in actual_dataset.contributors]
                 self.assertEqual(expected_dataset_id, actual_dataset.id)
-                self.assertCountEqual(expected_artifacts, actual_dataset.artifacts)
-                self.assertCountEqual(expected_deployment_directories, actual_dataset.deployment_directories)
-                self.assertCountEqual(expected_contributors, actual_dataset.contributors)
+                self.assertCountEqual(expected_artifacts, actual_artifacts)
+                self.assertCountEqual(expected_deployment_directories, actual_deployment_directories)
+                self.assertCountEqual(expected_contributors, actual_contributors)
 
     def test__list__ok(self):
         generate = 2
         generated_ids = [Dataset.create(**BogusDatasetParams.get()).id for _ in range(generate)]
         dataset = Dataset.list()
         self.assertTrue(set(generated_ids).issubset([d.id for d in dataset]))
+
+    def test__cascade_delete_project_with_dataset__ok(self):
+        # Create the dataset
+        test_dataset = Dataset.create(
+            **BogusDatasetParams.get(
+                project_id="test_project_id",
+                project_status=ProjectStatus.LIVE.name,
+                artifacts=[{}],
+                deployment_directories=[{}],
+                contributors=[{"id": "test_contributor_id"}, {"name": "bob"}],
+            )
+        )
+        test_dataset_ids = [(test_dataset.id, DbDataset)]
+        test_artifact_ids = [(art.id, DbDatasetArtifact) for art in test_dataset.artifacts]
+        test_deployed_directory_ids = [(dep.id, DbDeploymentDirectory) for dep in test_dataset.deployment_directories]
+        if test_dataset.contributors[0].name == "bob":
+            test_contributor_bob_id = [(test_dataset.contributors[0].id, DbContributor)]
+            test_contributor_id = [(test_dataset.contributors[1].id, DbContributor)]
+        else:
+            test_contributor_bob_id = [(test_dataset.contributors[1].id, DbContributor)]
+            test_contributor_id = [(test_dataset.contributors[0].id, DbContributor)]
+        test_project_ids = [(("test_project_id", ProjectStatus.LIVE.name), DbProject)]
+
+        with self.subTest("verify everything exists"):
+            expected_exists = (
+                test_contributor_id
+                + test_contributor_bob_id
+                + test_project_ids
+                + test_dataset_ids
+                + test_artifact_ids
+                + test_deployed_directory_ids
+            )
+            self.assertRowsExist(expected_exists)
+
+        # Delete the dataset
+        test_dataset.delete()
+
+        with self.subTest("Verify Deletion"):
+            expected_deleted = (
+                test_dataset_ids + test_artifact_ids + test_deployed_directory_ids + test_contributor_bob_id
+            )
+            expected_exists = test_contributor_id + test_project_ids
+            self.assertRowsDeleted(expected_deleted)
+            self.assertRowsExist(expected_exists)
+
+    def assertRowsDeleted(self, tests: typing.List[typing.Tuple[str, Base]]):
+        """
+        Verify if rows have been deleted from the database.
+        :param tests: a list of tuples with (primary_key, table)
+        """
+        db = DbUtils()
+        db.session.expire_all()
+        for p_key, table in tests:
+            if len(p_key) == 2:
+                # handle the special case for projects with a composite primary key
+                actual = db.query([table], [table.id == p_key[0], table.status == p_key[1]])
+            else:
+                actual = db.query([table], [table.id == p_key])
+            self.assertFalse(actual, f"Row not deleted {table.__name__}:{p_key}")
+
+    def assertRowsExist(self, tests):
+        """
+        Verify if rows exist in the database.
+        :param tests: a list of tuples with (primary_key, table)
+        """
+        db = DbUtils()
+        db.session.expire_all()
+        for p_key, table in tests:
+            if len(p_key) == 2:
+                # handle the special case for projects with a composite primary key
+                actual = db.query([table], [table.id == p_key[0], table.status == p_key[1]])
+            else:
+                actual = db.query([table], [table.id == p_key])
+            self.assertTrue(actual, f"Row does not exist {table.__name__}:{p_key}")

--- a/tests/unit/backend/corpora/common/entities/test_project.py
+++ b/tests/unit/backend/corpora/common/entities/test_project.py
@@ -9,9 +9,11 @@ from backend.corpora.common.corpora_orm import (
     DbDataset,
     DbUser,
 )
+from backend.corpora.common.entities import Dataset
 from backend.corpora.common.entities.entity import logger as entity_logger
 from backend.corpora.common.entities.project import Project
-from tests.unit.backend.utils import BogusProjectParams
+from backend.corpora.common.utils.db_utils import DbUtils
+from tests.unit.backend.utils import BogusProjectParams, BogusDatasetParams
 
 
 class TestProject(unittest.TestCase):
@@ -142,3 +144,46 @@ class TestProject(unittest.TestCase):
         generated_ids = [Project.create(**BogusProjectParams.get()).id for _ in range(generate)]
         projects = Project.list()
         self.assertTrue(set(generated_ids).issubset([p.id for p in projects]))
+
+    def test__cascade_delete_project__ok(self):
+        test_project = Project.create(**BogusProjectParams.get(links=[{}]))
+        db = DbUtils()
+        test_project_id = test_project.id
+        test_link_id = test_project.links[0].id
+
+        # Check if the link exists.
+        expected_id = test_link_id
+        actual_id = db.query([DbProjectLink], [DbProjectLink.id == test_link_id])[0].id
+        self.assertEqual(expected_id, actual_id)
+
+        # The Project is deleted
+        db.session.delete(test_project.db_object)
+        expected_results = None
+        actual_results = Project.get_project(test_project_id)
+        self.assertEqual(expected_results, actual_results)
+
+        # The link should also be deleted.
+        expected_results = []
+        actual_results = db.query([DbProjectLink], [DbProjectLink.id == test_link_id])
+        self.assertEqual(expected_results, actual_results)
+
+    def test__cascade_delete_project_with_dataset__ok(self):
+        db = DbUtils()
+        test_project = Project.create(**BogusProjectParams.get())
+        expected_project_id = test_project.id
+        test_dataset = Dataset.create(
+            **BogusDatasetParams.get(project_id=test_project.id, project_status=test_project.status)
+        )
+        expected_dataset_id = test_dataset.id
+
+        # The Project is deleted
+        db.session.delete(test_project.db_object)
+        db.session.expire_all()
+        expected_results = None
+        actual_results = Project.get_project(expected_project_id)
+        self.assertEqual(expected_results, actual_results)
+
+        # The dataset is delete
+        expected_results = None
+        actual_results = Dataset.get(expected_dataset_id)
+        self.assertEqual(expected_results, actual_results)

--- a/tests/unit/backend/corpora/common/entities/utils.py
+++ b/tests/unit/backend/corpora/common/entities/utils.py
@@ -1,2 +1,0 @@
-def get_ids(iterable):
-    return [i.id for i in iterable]

--- a/tests/unit/backend/utils.py
+++ b/tests/unit/backend/utils.py
@@ -16,3 +16,30 @@ class BogusProjectParams:
         )
         bogus_data.update(**kwargs)
         return bogus_data
+
+
+class BogusDatasetParams:
+    @classmethod
+    def get(cls, **kwargs):
+        bogus_data = dict(
+            name="create_dataset",
+            organism="organism",
+            organism_ontology="123",
+            tissue="tissue",
+            tissue_ontology="123",
+            assay="assay",
+            assay_ontology="123",
+            disease="diseas",
+            disease_ontology="123",
+            sex="F",
+            ethnicity="ethnicity",
+            ethnicity_ontology="123",
+            source_data_location="location",
+            preprint_doi="preprint",
+            publication_doi="publication",
+            project_id="test_project_id",
+            project_status=ProjectStatus.LIVE.name,
+        )
+
+        bogus_data.update(**kwargs)
+        return bogus_data


### PR DESCRIPTION
Linking objects in corpora_orm to clean up when the parent is deleted.
Contributors are not delete when their dataset is deleted unless they are not connect to any other datasets.