### PR TITLE
Fixing api-server to deploy to multiple stages

### DIFF
--- a/backend/chalice/api_server/Makefile
+++ b/backend/chalice/api_server/Makefile
@@ -8,7 +8,7 @@ export EXPORT_ENV_VARS_TO_LAMBDA=APP_NAME DEPLOYMENT_STAGE
 export S3_DEPLOYMENT_FILE=s3://org-corpora-$(DEPLOYMENT_STAGE)-infra-$(ACCOUNT_ID)/chalice/$(APP_NAME)_deployed.json
 export LOCAL_DEPLOYED_PATH=.chalice/deployed
 export LOCAL_DEPLOYED_FILE=$(LOCAL_DEPLOYED_PATH)/$(DEPLOYMENT_STAGE).json
-export VPC_ID=$(shell aws ec2 describe-vpcs | jq -rc '.Vpcs[] | select((.Tags != null) and (.Tags[].Value == "sc-dev")) | .VpcId')
+export VPC_ID=$(shell aws ec2 describe-vpcs | jq -rc '.Vpcs[] | select((.Tags != null) and (.Tags[].Value == "sc-${DEPLOYMENT_STAGE}")) | .VpcId')
 export PRIVATE_SUBNET_IDS=$(shell aws ec2 describe-subnets | jq -rc '.Subnets[] | select((.Tags != null) and (.VpcId == "$(VPC_ID)") and (.Tags[].Value | contains("sc-$(DEPLOYMENT_STAGE)-private"))) | .SubnetId')
 export PRIVATE_SUBNET_ID_1=$(shell cut -d' ' -f1 <<<"$(PRIVATE_SUBNET_IDS)")
 export PRIVATE_SUBNET_ID_2=$(shell cut -d' ' -f2 <<<"$(PRIVATE_SUBNET_IDS)")


### PR DESCRIPTION
Adding DEPLOYMENT_STAGE as a variable when retrieving VPC_ID during the deployment process.

partial fix for #338 