### PR TITLE
496-DP-serve-static-assets

### DIFF
--- a/frontend/gatsby-config.js
+++ b/frontend/gatsby-config.js
@@ -1,38 +1,40 @@
 module.exports = {
-  siteMetadata: {
-    title: `data.humancellatlas.org`,
-    description: `Kick off your next, great Gatsby project with this default starter. This barebones starter ships with the main Gatsby configuration files you might need.`,
-    author: `@gatsbyjs`,
-  },
+  // (thuang): Prod build will serve static assets from this directory
+  // E.g., cellxgene.cziscience.com/dp/foo.js
+  assetPrefix: "/dp",
   plugins: [
     "gatsby-plugin-typescript",
     "gatsby-plugin-react-helmet",
     "gatsby-plugin-root-import",
     "gatsby-plugin-styled-components",
     {
-      resolve: `gatsby-source-filesystem`,
+      resolve: "gatsby-plugin-asset-path",
+    },
+    {
       options: {
         name: `images`,
         path: `${__dirname}/src/images`,
       },
+      resolve: `gatsby-source-filesystem`,
     },
     `gatsby-plugin-theme-ui`,
     `gatsby-transformer-sharp`,
     `gatsby-plugin-sharp`,
     {
-      resolve: `gatsby-plugin-manifest`,
       options: {
+        display: `minimal-ui`, // icon: `src/images/gatsby-icon.png`, // This path is relative to the root of the site.
         name: `gatsby-starter-default`,
         // eslint-disable-next-line @typescript-eslint/camelcase
         short_name: `starter`,
         // eslint-disable-next-line @typescript-eslint/camelcase
         start_url: `/`,
-        display: `minimal-ui`,
-        // icon: `src/images/gatsby-icon.png`, // This path is relative to the root of the site.
       },
+      resolve: `gatsby-plugin-manifest`,
     },
-    // this (optional) plugin enables Progressive Web App + Offline functionality
-    // To learn more, visit: https://gatsby.dev/offline
-    // `gatsby-plugin-offline`,
   ],
+  siteMetadata: {
+    author: `@gatsbyjs`,
+    description: `Kick off your next, great Gatsby project with this default starter. This barebones starter ships with the main Gatsby configuration files you might need.`,
+    title: `data.humancellatlas.org`,
+  },
 };

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -12862,6 +12862,31 @@
         }
       }
     },
+    "gatsby-plugin-asset-path": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/gatsby-plugin-asset-path/-/gatsby-plugin-asset-path-3.0.2.tgz",
+      "integrity": "sha512-XofmAtDhRP0Zo21O/ljdH8Bcrfn2BzaTC3lDXz6GsGymZ8wstfwRs6kGHwFGfjJIfaB0y26wGc3ADljRmLVk7g==",
+      "dev": true,
+      "requires": {
+        "fs-extra": "^7.0.0",
+        "history": "^4.7.2",
+        "react": "^16.4.2",
+        "react-router-dom": "^4.3.1"
+      },
+      "dependencies": {
+        "fs-extra": {
+          "version": "7.0.1",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
+          "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "jsonfile": "^4.0.0",
+            "universalify": "^0.1.0"
+          }
+        }
+      }
+    },
     "gatsby-plugin-manifest": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/gatsby-plugin-manifest/-/gatsby-plugin-manifest-2.3.3.tgz",
@@ -15498,6 +15523,20 @@
       "version": "8.9.1",
       "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-8.9.1.tgz",
       "integrity": "sha1-uKnFSTISqTkvAiK2SclhFJfr+4g="
+    },
+    "history": {
+      "version": "4.10.1",
+      "resolved": "https://registry.npmjs.org/history/-/history-4.10.1.tgz",
+      "integrity": "sha512-36nwAD620w12kuzPAsyINPWJqlNbij+hpK1k9XRloDtym8mxzGYl2c17LnV6IAGB2Dmg4tEa7G7DlawS0+qjew==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.1.2",
+        "loose-envify": "^1.2.0",
+        "resolve-pathname": "^3.0.0",
+        "tiny-invariant": "^1.0.2",
+        "tiny-warning": "^1.0.0",
+        "value-equal": "^1.0.1"
+      }
     },
     "hmac-drbg": {
       "version": "1.0.1",
@@ -21296,6 +21335,58 @@
         "tslib": "^1.0.0"
       }
     },
+    "react-router": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-4.3.1.tgz",
+      "integrity": "sha512-yrvL8AogDh2X42Dt9iknk4wF4V8bWREPirFfS9gLU1huk6qK41sg7Z/1S81jjTrGHxa3B8R3J6xIkDAA6CVarg==",
+      "dev": true,
+      "requires": {
+        "history": "^4.7.2",
+        "hoist-non-react-statics": "^2.5.0",
+        "invariant": "^2.2.4",
+        "loose-envify": "^1.3.1",
+        "path-to-regexp": "^1.7.0",
+        "prop-types": "^15.6.1",
+        "warning": "^4.0.1"
+      },
+      "dependencies": {
+        "hoist-non-react-statics": {
+          "version": "2.5.5",
+          "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-2.5.5.tgz",
+          "integrity": "sha512-rqcy4pJo55FTTLWt+bU8ukscqHeE/e9KWvsOW2b/a3afxQZhwkQdT1rPPCJ0rYXdj4vNcasY8zHTH+jF/qStxw==",
+          "dev": true
+        },
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+          "dev": true
+        },
+        "path-to-regexp": {
+          "version": "1.8.0",
+          "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.8.0.tgz",
+          "integrity": "sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==",
+          "dev": true,
+          "requires": {
+            "isarray": "0.0.1"
+          }
+        }
+      }
+    },
+    "react-router-dom": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-4.3.1.tgz",
+      "integrity": "sha512-c/MlywfxDdCp7EnB7YfPMOfMD3tOtIjrQlj/CKfNMBxdmpJP8xcz5P/UAFn3JbnQCNUxsHyVVqllF9LhgVyFCA==",
+      "dev": true,
+      "requires": {
+        "history": "^4.7.2",
+        "invariant": "^2.2.4",
+        "loose-envify": "^1.3.1",
+        "prop-types": "^15.6.1",
+        "react-router": "^4.3.1",
+        "warning": "^4.0.1"
+      }
+    },
     "react-side-effect": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/react-side-effect/-/react-side-effect-1.2.0.tgz",
@@ -22067,6 +22158,12 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
       "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g=="
+    },
+    "resolve-pathname": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pathname/-/resolve-pathname-3.0.0.tgz",
+      "integrity": "sha512-C7rARubxI8bXFNB/hqcp/4iUeIXJhJZvFPFPiSPRnhU5UPxzMFIl+2E6yY6c4k9giDJAhtV+enfA+G89N6Csng==",
+      "dev": true
     },
     "resolve-url": {
       "version": "0.2.1",
@@ -24513,6 +24610,12 @@
       "resolved": "https://registry.npmjs.org/timsort/-/timsort-0.3.0.tgz",
       "integrity": "sha1-QFQRqOfmM5/mTbmiNN4R3DHgK9Q="
     },
+    "tiny-invariant": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.1.0.tgz",
+      "integrity": "sha512-ytxQvrb1cPc9WBEI/HSeYYoGD0kWnGEOR8RY6KomWLBVhqz0RgTwVO9dLrGz7dC+nN9llyI7OKAgRq8Vq4ZBSw==",
+      "dev": true
+    },
     "tiny-warning": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/tiny-warning/-/tiny-warning-1.0.3.tgz",
@@ -25259,6 +25362,12 @@
         "spdx-correct": "^3.0.0",
         "spdx-expression-parse": "^3.0.0"
       }
+    },
+    "value-equal": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/value-equal/-/value-equal-1.0.1.tgz",
+      "integrity": "sha512-NOJ6JZCAWr0zlxZt+xqCHNTEKOsrks2HQd4MqhP1qy4z1SkbEP467eNx6TgDKXMvUOb+OENfJCZwM+16n7fRfw==",
+      "dev": true
     },
     "vary": {
       "version": "1.1.2",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -45,6 +45,7 @@
     "eslint-plugin-react": "^7.20.0",
     "eslint-plugin-react-hooks": "^2.5.1",
     "eslint-plugin-sonarjs": "^0.5.0",
+    "gatsby-plugin-asset-path": "^3.0.2",
     "gatsby-plugin-root-import": "^2.0.5",
     "lint-staged": "^10.2.11",
     "prettier": "^1.19.1",
@@ -59,7 +60,7 @@
   ],
   "license": "MIT",
   "scripts": {
-    "build": "gatsby build",
+    "build": "gatsby build --prefix-paths",
     "develop": "gatsby develop",
     "format": "prettier --write \"**/*.{js,jsx,json,md}\"",
     "start": "npm run develop",


### PR DESCRIPTION
Changes:

1. Adds `gatsby-plugin-asset-path` plugin to serve our static assets from `/dp/*` than root `/*`
2. Update `npm run build` command to add flag `--prefix-paths` as required by the plugin
3. Proof below that prod build now serves static assets from `/dp/*` namespace 🎉 

<img width="1340" alt="Screen Shot 2020-08-14 at 3 15 44 PM" src="https://user-images.githubusercontent.com/6309723/90296718-24364b80-de41-11ea-9334-c2eeb9452d24.png">

PTAL! Thank you!

closes #496 