### PR TITLE
Pin s3fs dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,6 +15,6 @@ pandas
 PyMySQL==0.9.3
 pytest
 requests>=2.22.0
-s3fs
+s3fs==0.4.2
 scanpy
 -r ./backend/chalice/api_server/requirements.txt


### PR DESCRIPTION
This mirrors a change in cellxgene. The latest s3fs creates a bunch of errors in aiobotocore.