### PR TITLE
thuang-499-smoke-test-part-1

### DIFF
--- a/.github/workflows/push-tests.yml
+++ b/.github/workflows/push-tests.yml
@@ -31,6 +31,7 @@ jobs:
         run: |
           pip install flake8-black
           cd frontend
+          cp src/configs/local.js src/configs/configs.js
           npm install
       - name: Lint with flake8-black
         run: |
@@ -43,32 +44,32 @@ jobs:
   unit-test:
     runs-on: ubuntu-latest
     steps:
-    - name: Configure AWS Credentials
-      uses: aws-actions/configure-aws-credentials@v1
-      with:
-        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY }}
-        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-        aws-region: us-west-2
-        role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
-        role-duration-seconds: 900  
-    - uses: actions/checkout@v2
-    - name: Set up Python 3.7
-      uses: actions/setup-python@v1
-      with:
-        python-version: 3.7
-    - name: Python cache
-      uses: actions/cache@v1
-      with:
-        path: ~/.cache/pip
-        key: ${{ runner.os }}-pip-${{ hashFiles('requirements*.txt') }}
-        restore-keys: |
-          ${{ runner.os }}-pip-
-    - name: Install dependencies
-      run: |
-        pip install -r requirements.txt
-        brew install moreutils
-        make package -C ./backend/chalice/api_server
-    - name: Run unit tests
-      run: |
-        make unit-test
-        bash <(curl -s https://codecov.io/bash) -cF backend,python,unitTest
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-west-2
+          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+          role-duration-seconds: 900
+      - uses: actions/checkout@v2
+      - name: Set up Python 3.7
+        uses: actions/setup-python@v1
+        with:
+          python-version: 3.7
+      - name: Python cache
+        uses: actions/cache@v1
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('requirements*.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
+      - name: Install dependencies
+        run: |
+          pip install -r requirements.txt
+          brew install moreutils
+          make package -C ./backend/chalice/api_server
+      - name: Run unit tests
+        run: |
+          make unit-test
+          bash <(curl -s https://codecov.io/bash) -cF backend,python,unitTest

--- a/.gitignore
+++ b/.gitignore
@@ -117,6 +117,8 @@ venv/
 ENV/
 env.bak/
 venv.bak/
+bin/
+pyvenv.cfg
 
 # Spyder project settings
 .spyderproject

--- a/frontend/.env.development
+++ b/frontend/.env.development
@@ -1,9 +1,0 @@
-#!/usr/bin/env bash
-AUTH0_DOMAIN=czi-single-cell.auth0.com
-AUTH0_CLIENT_ID=WgNfOFY5vVO6780kOEXsOD2S2uSbuXB4
-AUTH0_CALLBACK=http://localhost:8000
-
-# Dev env API_URL: https://api.dev.corpora.cziscience.com
-API_URL=http://localhost:5000
-CXG_URL=http://cellxgene-dev.us-west-2.elasticbeanstalk.com
-ENV=dev

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -55,6 +55,9 @@ typings/
 .env*
 !.env.development
 
+# configs
+src/configs/configs.js
+
 # gatsby files
 .cache/
 public

--- a/frontend/Makefile
+++ b/frontend/Makefile
@@ -23,6 +23,8 @@ clean:
 .PHONY: retrieve-vars
 retrieve-vars:
 	aws s3 cp $(S3_ENVIRONMENT_FILE) .env.production
+	# Copy the appropriate configs
+	cp src/configs/$(DEPLOYMENT_STAGE).js src/configs/configs.js
 
 .PHONY: upload-vars
 upload-vars:

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,54 +1,44 @@
-<!-- AUTO-GENERATED-CONTENT:START (STARTER) -->
-<p align="center">
-  <a href="https://www.gatsbyjs.org">
-    <img alt="Gatsby" src="https://www.gatsbyjs.org/monogram.svg" width="60" />
-  </a>
-</p>
-<h1 align="center">
-  Data Portal Frontend
-</h1>
-<p align="center">
-  Powered by Gatsby
-</p>
+# Development
 
-## Development
+1. **Install dependencies.**
 
-1.  **Install dependencies.**
+   ```shell
+   # Install gatsby globally
+   npm install -g gatsby
 
-    ```shell
-    # Install gatsby globally
-    npm install -g gatsby
+   # Install project dependencies
+   npm install
+   ```
 
-    # Install project dependencies
-    npm install
-    ```
+1. **Set Up Environment Variables**
 
-1.  **Set Up Environment Variables**
+   Create the the environment file and populate the variables.
 
-    Create the the environment file and populate the variables.
+1. **Host the backend locally.**
 
-1.  **Host the backend locally.**
+   Follow [backend instructions](../backend/chalice/api_server/README.md#Development)to deploy the backend API on
+   `http://localhost:5000`.
 
-    Follow [backend instructions](../backend/chalice/api_server/README.md#Development)to deploy the backend API on
-    `http://localhost:5000`.
+1. **Build and launch the frontend locally.**
 
-1.  **Build and launch the frontend locally.**
+   1. Create `frontend/configs/configs.js` and paste content from
+      `frontend/configs/local.js`
+   1. Run `gatsby develop`
 
-    ```shell
-    gatsby develop
-    ```
+   Your site is now running at `http://localhost:8000` with hot re-loading!
 
-    Your site is now running at `http://localhost:8000` with hot re-loading!
+1. **Open the source code and start editing!**
 
-1.  **Open the source code and start editing!**
-
-    Modify code in the `src` directory, save your changes and the browser will update in real time.
+   Modify code in the `src` directory, save your changes and the browser will update in real time.
 
 ## Environment Variables
 
-The environment variables used to deploy the website. The variables should be stored in a file name _env.development_
-for development and _env.production_ for production deployments. Do not store sensitive data in the environment
-variables.
+The environment variables for the web application. The variables are stored in /frontend/configs/\*. E.g., `frontend/configs/local.js`
+
+For local development, please copy `local.js` to a new file named `configs.js`
+in the same directory (`frontend/configs/configs.js`)
+
+WARNING: Do not store sensitive data in the environment variables.
 
 | Name            | Description                                          |
 | --------------- | ---------------------------------------------------- |
@@ -56,7 +46,6 @@ variables.
 | AUTH0_CLIENT_ID | The client id of the Auth0 application for this site |
 | AUDIENCE        | The domain of the corpora api                        |
 | API_URL         | The URL to the corpora api                           |
-| CXG_URL         | The URL to CellxGene                                 |
 
 ## Deployment
 

--- a/frontend/src/configs/dev.js
+++ b/frontend/src/configs/dev.js
@@ -1,0 +1,5 @@
+const configs = {
+  API_URL: "https://api.dev.corpora.cziscience.com",
+};
+
+if (typeof module !== "undefined") module.exports = configs;

--- a/frontend/src/configs/local.js
+++ b/frontend/src/configs/local.js
@@ -1,0 +1,8 @@
+// (thuang): For local development, please copy the content of this file
+// to a new file named `configs.js` in this directory.
+
+const configs = {
+  API_URL: "http://localhost:5000",
+};
+
+if (typeof module !== "undefined") module.exports = configs;

--- a/frontend/src/configs/prod.js
+++ b/frontend/src/configs/prod.js
@@ -1,0 +1,5 @@
+const configs = {
+  API_URL: "https://api.corpora.cziscience.com",
+};
+
+if (typeof module !== "undefined") module.exports = configs;

--- a/frontend/src/configs/staging.js
+++ b/frontend/src/configs/staging.js
@@ -1,0 +1,5 @@
+const configs = {
+  API_URL: "https://api.staging.corpora.cziscience.com",
+};
+
+if (typeof module !== "undefined") module.exports = configs;

--- a/frontend/src/globals.ts
+++ b/frontend/src/globals.ts
@@ -1,2 +1,0 @@
-export const API_URL = process.env.API_URL;
-export const CXG_URL = process.env.CXG_URL;

--- a/frontend/src/pages/index.tsx
+++ b/frontend/src/pages/index.tsx
@@ -1,7 +1,7 @@
 import React, { FC, useEffect, useState } from "react";
 import CookieBanner from "src/components/CookieBanner";
 import ProjectsList from "src/components/ProjectList";
-import { API_URL } from "src/globals";
+import { API_URL } from "src/configs/configs";
 import { Project } from "../common/entities";
 import Layout from "../components/Layout";
 import SEO from "../components/seo";


### PR DESCRIPTION
This PR moves away from using `.env.[ENV]` to define non-sensitive app configurations to just copy the variables from `src/configs/[ENV].js` to `src/configs/configs.js`.

This way we decouple build env with config env, in order to allow Gatsby prod build to still hit local API endpoint (will be part 2 smoke test PR)

Changes:
1. Update README to reflect the new setup
2. Update deployment yml accordingly
3. Remove `.env.development`
4. Update `.gitignore`
5. Update the app to use the new config file to get `API_URL`

QA steps:
1. Copy `src/configs/dev.js` to `src/configs/configs.js` (please create the file if not available)
2. Run `npm run develop`
3. Browse `http://localhost:8000/` and you should see a list of datasets that match the `dev` env DB