### PR TITLE
Fix local library imports to be relative

### DIFF
--- a/backend/corpora/common/authorizer.py
+++ b/backend/corpora/common/authorizer.py
@@ -1,10 +1,12 @@
-from functools import lru_cache
-import requests
 import os
+from functools import lru_cache
+
+import requests
 from chalice import UnauthorizedError
-from backend.corpora.common.corpora_config import CorporaAuthConfig
 from jose import jwt
 from jose.exceptions import ExpiredSignatureError, JWTError, JWTClaimsError
+
+from .corpora_config import CorporaAuthConfig
 
 
 def assert_authorized_token(token: str) -> dict:

--- a/backend/corpora/common/entities/dataset.py
+++ b/backend/corpora/common/entities/dataset.py
@@ -1,7 +1,7 @@
 import typing
 import uuid
 
-from backend.corpora.common.entities.dataset_asset import DatasetAsset
+from .dataset_asset import DatasetAsset
 from .entity import Entity
 from ..corpora_orm import DbDataset, DbDatasetArtifact, DbDeploymentDirectory, DbContributor, DbDatasetContributor
 

--- a/backend/corpora/lambdas/api/v1/authentication.py
+++ b/backend/corpora/lambdas/api/v1/authentication.py
@@ -1,17 +1,18 @@
-from flask import make_response, jsonify, current_app, request, redirect, after_this_request, g, Response
+import base64
 import json
 import os
+from typing import Optional
+from urllib.parse import urlencode
+
 import requests
 from authlib.integrations.flask_client import OAuth
 from authlib.integrations.flask_client.remote_app import FlaskRemoteApp
-from urllib.parse import urlencode
-import base64
-from ....common.authorizer import get_userinfo, assert_authorized_token
-from backend.corpora.common.corpora_config import CorporaAuthConfig
-from jose.exceptions import ExpiredSignatureError
 from chalice import UnauthorizedError
-from typing import Optional
+from flask import make_response, jsonify, current_app, request, redirect, after_this_request, g, Response
+from jose.exceptions import ExpiredSignatureError
 
+from ....common.authorizer import get_userinfo, assert_authorized_token
+from ....common.corpora_config import CorporaAuthConfig
 
 # global oauth client
 oauth_client = None

--- a/tests/unit/backend/chalice/api_server/__init__.py
+++ b/tests/unit/backend/chalice/api_server/__init__.py
@@ -12,8 +12,8 @@ class BaseAPITest:
 
     @classmethod
     def setUpClass(cls):
-        corpora_api_dir = os.path.join(os.environ["CORPORA_HOME"], "backend", "chalice", "api_server")
-        cls.app = ChaliceTestHarness(corpora_api_dir)
+        cls.corpora_api_dir = os.path.join(os.environ["CORPORA_HOME"], "backend", "chalice", "api_server")
+        cls.app = ChaliceTestHarness(cls.corpora_api_dir)
         cls.maxDiff = None  # Easier to compare json responses.
 
     @staticmethod

--- a/tests/unit/backend/chalice/api_server/test_v1_auth.py
+++ b/tests/unit/backend/chalice/api_server/test_v1_auth.py
@@ -98,7 +98,7 @@ class TestAuth(BaseAPITest, unittest.TestCase):
         def restore_path(p):
             sys.path = p
 
-        sys.path.insert(0, os.path.join(cls.corpora_api_dir, "chalicelib"))  # noqa
+        sys.path.insert(0, os.path.join(self.corpora_api_dir, "chalicelib"))  # noqa
         self.addCleanup(restore_path, old_path)
         from corpora.common.corpora_config import CorporaAuthConfig
 

--- a/tests/unit/backend/chalice/api_server/test_v1_auth.py
+++ b/tests/unit/backend/chalice/api_server/test_v1_auth.py
@@ -1,5 +1,6 @@
 import json
 import os
+import sys
 import unittest
 import urllib.parse
 import jose.jwt
@@ -7,7 +8,6 @@ import time
 from flask import Flask, jsonify, make_response, request, redirect
 import random
 from multiprocessing import Process
-from backend.corpora.common.corpora_config import CorporaAuthConfig
 from tests.unit.backend.chalice.api_server import BaseAPITest
 
 # Create a mocked out oauth server, which servers all the endpoints needed by the oauth type.
@@ -93,6 +93,17 @@ class TestAuth(BaseAPITest, unittest.TestCase):
         self.assertEqual(userinfo["email_verified"], True)
 
     def test__auth_flow(self):
+        old_path = sys.path.copy()
+
+        def restore_path(p):
+            sys.path = p
+
+        sys.path.insert(0, os.path.join(cls.corpora_api_dir, "chalicelib"))  # noqa
+        self.addCleanup(restore_path, old_path)
+        from corpora.common.corpora_config import CorporaAuthConfig
+
+        # Use the CorporaAuthConfig used by the chalice app
+
         self.auth_config = CorporaAuthConfig()
         self.auth_config._config["api_base_url"] = f"http://localhost:{PORT}"
         self.auth_config._config["callback_base_url"] = "http://localhost:5000"


### PR DESCRIPTION
Importing the CorpaAuthConfig used by the chalice app to ensure the same class is used in the test. Otherwise there are two CorpaAuthConfig class. One is defined in backend/chalice/api_server/chalicelib/corpora, the other is defined in backend/corpora. We are interested in testing the former.