### PR TITLE
thuang-download-buttons-feedback

### DIFF
--- a/frontend/src/components/ProjectList/common/layout.ts
+++ b/frontend/src/components/ProjectList/common/layout.ts
@@ -1,10 +1,5 @@
-// (thuang): Unit is %
+// (thuang): Unit is flex-grow
 export enum LAYOUT {
-  NAME = 48.33,
-  NAME_MARGIN = 4.17,
-  VIEW = 14.81,
-  VIEW_MARGIN = 6.02,
-  DOWNLOAD = 16,
-  DOWNLOAD_MARGIN = 6.02,
-  INFO = 26.67,
+  NAME = 2.5,
+  SMALL_COLUMN = 1,
 }

--- a/frontend/src/components/ProjectList/components/Dataset/common/style.ts
+++ b/frontend/src/components/ProjectList/components/Dataset/common/style.ts
@@ -1,0 +1,15 @@
+import { fontStyle } from "src/components/common/theme";
+import { LAYOUT } from "src/components/ProjectList/common/layout";
+import styled, { css } from "styled-components";
+
+export const columnStyle = css`
+  align-items: center;
+  display: flex;
+  flex: ${LAYOUT.SMALL_COLUMN};
+  justify-content: center;
+`;
+
+export const SmallColumn = styled.div`
+  ${columnStyle}
+  ${fontStyle}
+`;

--- a/frontend/src/components/ProjectList/components/Dataset/components/DownloadDataset/index.tsx
+++ b/frontend/src/components/ProjectList/components/Dataset/components/DownloadDataset/index.tsx
@@ -1,7 +1,8 @@
 import React, { FC } from "react";
 import Modal from "src/components/common/Modal";
+import { SmallColumn } from "../../common/style";
 import Content from "./components/Content";
-import { StyledButton, Wrapper } from "./style";
+import { StyledButton } from "./style";
 
 const DownloadDataset: FC = () => {
   const [isOpen, setIsOpen] = React.useState(false);
@@ -9,19 +10,14 @@ const DownloadDataset: FC = () => {
   const toggleOpen = () => setIsOpen(!isOpen);
 
   return (
-    <div>
-      <Wrapper>
-        <StyledButton
-          data-test-id="dataset-download-button"
-          onClick={toggleOpen}
-        >
-          Download{" "}
-        </StyledButton>
-        <Modal isOpen={isOpen} onClose={toggleOpen}>
-          <Content />
-        </Modal>
-      </Wrapper>
-    </div>
+    <SmallColumn>
+      <StyledButton data-test-id="dataset-download-button" onClick={toggleOpen}>
+        Download{" "}
+      </StyledButton>
+      <Modal isOpen={isOpen} onClose={toggleOpen}>
+        <Content />
+      </Modal>
+    </SmallColumn>
   );
 };
 

--- a/frontend/src/components/ProjectList/components/Dataset/components/DownloadDataset/style.ts
+++ b/frontend/src/components/ProjectList/components/Dataset/components/DownloadDataset/style.ts
@@ -1,15 +1,5 @@
 import { fontStyle } from "src/components/common/theme";
-import { LAYOUT } from "src/components/ProjectList/common/layout";
 import styled from "styled-components";
-
-export const Wrapper = styled.div`
-  width: ${LAYOUT.DOWNLOAD}%;
-  margin-right: ${LAYOUT.DOWNLOAD_MARGIN}%;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  height: 5em;
-`;
 
 export const StyledButton = styled.button`
   ${fontStyle}

--- a/frontend/src/components/ProjectList/components/Dataset/components/MoreInformation/index.tsx
+++ b/frontend/src/components/ProjectList/components/Dataset/components/MoreInformation/index.tsx
@@ -1,7 +1,7 @@
 import React, { FC } from "react";
 import { Project } from "src/common/entities";
-import { StyledAnchor, Wrapper } from "./style";
-
+import { SmallColumn } from "../../common/style";
+import { StyledAnchor } from "./style";
 interface AnchorProps {
   url: string;
 }
@@ -41,7 +41,7 @@ const MoreInformation: FC<Props> = ({ links }) => {
     }
   });
 
-  return <Wrapper>{styledLinks}</Wrapper>;
+  return <SmallColumn>{styledLinks}</SmallColumn>;
 };
 
 export default MoreInformation;

--- a/frontend/src/components/ProjectList/components/Dataset/components/MoreInformation/style.ts
+++ b/frontend/src/components/ProjectList/components/Dataset/components/MoreInformation/style.ts
@@ -1,14 +1,5 @@
 import { fontStyle } from "src/components/common/theme";
-import { LAYOUT } from "src/components/ProjectList/common/layout";
 import styled from "styled-components";
-
-export const Wrapper = styled.div`
-  width: ${LAYOUT.INFO}%;
-  align-items: center;
-  line-height: 1.2;
-  padding: 12px 0;
-  display: flex;
-`;
 
 export const StyledAnchor = styled.a`
   ${fontStyle}

--- a/frontend/src/components/ProjectList/components/Dataset/components/ViewDataset/index.tsx
+++ b/frontend/src/components/ProjectList/components/Dataset/components/ViewDataset/index.tsx
@@ -1,7 +1,8 @@
 /* eslint-disable @typescript-eslint/camelcase */
 import React, { FC } from "react";
 import { DatasetDeployment } from "src/common/entities";
-import { StyledAnchor, Wrapper } from "./style";
+import { SmallColumn } from "../../common/style";
+import { StyledAnchor } from "./style";
 
 interface Props {
   deployments: DatasetDeployment[];
@@ -13,7 +14,7 @@ const ViewDataset: FC<Props> = ({ deployments }) => {
   const deployment = deployments[0];
 
   return (
-    <Wrapper>
+    <SmallColumn>
       <StyledAnchor
         key={deployment.url}
         href={deployment.url}
@@ -24,7 +25,7 @@ const ViewDataset: FC<Props> = ({ deployments }) => {
         View
         <br />
       </StyledAnchor>
-    </Wrapper>
+    </SmallColumn>
   );
 };
 

--- a/frontend/src/components/ProjectList/components/Dataset/components/ViewDataset/style.ts
+++ b/frontend/src/components/ProjectList/components/Dataset/components/ViewDataset/style.ts
@@ -1,19 +1,5 @@
 import { BLUE, fontStyle } from "src/components/common/theme";
-import { LAYOUT } from "src/components/ProjectList/common/layout";
 import styled from "styled-components";
-
-export const Wrapper = styled.div`
-  width: ${LAYOUT.VIEW}%;
-  margin-right: ${LAYOUT.VIEW_MARGIN}%;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-`;
-
-export const SelectWrapper = styled.div`
-  display: flex;
-  position: relative;
-`;
 
 export const StyledAnchor = styled.a`
   ${fontStyle}

--- a/frontend/src/components/ProjectList/components/Dataset/style.ts
+++ b/frontend/src/components/ProjectList/components/Dataset/style.ts
@@ -15,8 +15,7 @@ export const Wrapper = styled.div`
 `;
 
 export const Name = styled.div`
-  width: ${LAYOUT.NAME}%;
-  margin-right: ${LAYOUT.NAME_MARGIN}%;
+  flex: ${LAYOUT.NAME};
   display: flex;
   align-items: center;
   line-height: 1.3;

--- a/frontend/src/components/ProjectList/components/Heading/index.tsx
+++ b/frontend/src/components/ProjectList/components/Heading/index.tsx
@@ -1,6 +1,7 @@
 import React, { FC } from "react";
 import questionMarkSvg from "src/components/ProjectList/components/Heading/questionMark.svg";
-import { Download, Info, Name, QuestionMark, View, Wrapper } from "./style";
+import { SmallColumn } from "../Dataset/common/style";
+import { Name, QuestionMark, Wrapper } from "./style";
 
 const TOOLTIP_MESSAGE = `cellxgene augments datasets with a minimal set of metadata fields designed to enable comparisons across datasets. In cases where these columns conflict with author's metadata, the author's columns are prefixed by "original_"`;
 
@@ -8,14 +9,14 @@ const Heading: FC = () => {
   return (
     <Wrapper>
       <Name>Dataset name</Name>
-      <View>
+      <SmallColumn>
         View in cellxgene
         <span title={TOOLTIP_MESSAGE}>
           <QuestionMark src={questionMarkSvg} alt="question mark" />
         </span>
-      </View>
-      <Download>Download dataset</Download>
-      <Info>More information</Info>
+      </SmallColumn>
+      <SmallColumn>Download dataset</SmallColumn>
+      <SmallColumn>More information</SmallColumn>
     </Wrapper>
   );
 };

--- a/frontend/src/components/ProjectList/components/Heading/style.ts
+++ b/frontend/src/components/ProjectList/components/Heading/style.ts
@@ -1,6 +1,6 @@
 import { fontStyle as fontStyleBase } from "src/components/common/theme";
-import { LAYOUT } from "src/components/ProjectList/common/layout";
 import styled, { css } from "styled-components";
+import { LAYOUT } from "../../common/layout";
 
 const fontStyle = css`
   ${fontStyleBase}
@@ -16,22 +16,7 @@ export const Wrapper = styled.div`
 
 export const Name = styled.div`
   ${fontStyle}
-  margin-right: ${LAYOUT.NAME_MARGIN}%;
-  width: ${LAYOUT.NAME}%;
-`;
-
-export const View = styled.div`
-  ${fontStyle}
-  margin-right: ${LAYOUT.VIEW_MARGIN}%;
-  width: ${LAYOUT.VIEW}%;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-`;
-
-export const Info = styled.div`
-  ${fontStyle}
-  width: ${LAYOUT.INFO}%;
+  flex: ${LAYOUT.NAME};
 `;
 
 export const QuestionMark = styled.img`
@@ -41,13 +26,4 @@ export const QuestionMark = styled.img`
   height: 15px;
   top: 3px;
   left: 5px;
-`;
-
-export const Download = styled.div`
-  ${fontStyle}
-  margin-right: ${LAYOUT.DOWNLOAD_MARGIN}%;
-  width: ${LAYOUT.DOWNLOAD}%;
-  display: flex;
-  align-items: center;
-  justify-content: center;
 `;


### PR DESCRIPTION
I updated the column to use `flex-grow` instead of percentage, since flex-grow is easier to use and less brittle, as shown below in OLD, where the percentage is consistent between the header and the column below, but somehow it's still not aligned

NEW:
<img width="1516" alt="Screen Shot 2020-09-15 at 12 51 47 PM" src="https://user-images.githubusercontent.com/6309723/93257914-6f9a8d00-f752-11ea-8ea5-c41f5db84a38.png">

OLD:
<img width="1516" alt="Screen Shot 2020-09-15 at 12 51 47 PM" src="https://user-images.githubusercontent.com/1429913/93135296-f25a1400-f68e-11ea-9910-4f33a28eae13.png">