### PR TITLE
Dunitz/565 auto scale test

### DIFF
--- a/.github/workflows/scale-test.yml
+++ b/.github/workflows/scale-test.yml
@@ -1,0 +1,31 @@
+name: "Scale test api (via cloudfront)"
+
+on:
+  schedule:
+    - cron: "0 0 * * Sun"
+  push:
+    branches:
+      - dunitz/565-auto-scale-test
+
+jobs:
+  locust-build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python 3.7
+        uses: actions/setup-python@v1
+        with:
+          python-version: 3.7
+      - name: Install dependencies
+        run: |
+          pip install locust
+      - name: Call script
+        run: |
+          locust -f scripts/scale_test.py --headless -u 30 -r 10 --host https://api.cellxgene.dev.single-cell.czi.technology/ --run-time 1m 2>&1 | tee locust_dev_stats.txt
+      - name: Slack success webhook
+        env:
+          STATS: $(tail -n 14 locust_dev_stats.txt)
+        run: |
+          echo $STATS
+
+

--- a/.github/workflows/scale-test.yml
+++ b/.github/workflows/scale-test.yml
@@ -3,9 +3,6 @@ name: "Scale test api (via cloudfront)"
 on:
   schedule:
     - cron: "0 0 * * Sun"
-  push:
-    branches:
-      - dunitz/565-auto-scale-test
 
 jobs:
   locust-build:
@@ -19,13 +16,15 @@ jobs:
       - name: Install dependencies
         run: |
           pip install locust
-      - name: Call script
+      - name: Dev Scale Test
         run: |
-          locust -f scripts/scale_test.py --headless -u 30 -r 10 --host https://api.cellxgene.dev.single-cell.czi.technology/ --run-time 1m 2>&1 | tee locust_dev_stats.txt
+          locust -f scripts/scale_test.py --headless -u 30 -r 10 --host https://api.cellxgene.dev.single-cell.czi.technology/ --run-time 5m 2>&1 | tee locust_dev_stats.txt
       - name: Slack success webhook
         env:
-          STATS: $(tail -n 14 locust_dev_stats.txt)
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
         run: |
-          echo $STATS
+          DEV_STATS=$(tail -n 13 locust_dev_stats.txt)
+          DEV_MSG="\`\`\`DEV SCALE TEST RESULTS: ${DEV_STATS}\`\`\`"
+          curl -X POST -H 'Content-type: application/json' --data "{'text':'${DEV_MSG}'}" $SLACK_WEBHOOK
 
 

--- a/scripts/scale_test.py
+++ b/scripts/scale_test.py
@@ -1,6 +1,6 @@
 import random
 import time
-from locust import HttpUser, between, task, events
+from locust import HttpUser, between, task
 
 random.seed(time.time())
 
@@ -27,19 +27,3 @@ class WebsiteUser(HttpUser):
     def get_project_info(self):
         self.client.get(random.choice(self.project_urls))
 
-    @events.quitting.add_listener
-    def _(environment, **kw):
-        if environment.stats.total.fail_ratio > 0.01:
-            msg = "Test failed due to failure ratio > 1%"
-            environment.process_exit_code = 1
-        elif environment.stats.total.avg_response_time > 200:
-            msg = "Test failed due to average response time ratio > 200 ms"
-            environment.process_exit_code = 1
-        elif environment.stats.total.get_response_time_percentile(0.95) > 500:
-            msg = "Test failed due to 95th percentile response time > 500 ms"
-            environment.process_exit_code = 1
-        else:
-            environment.process_exit_code = 0
-
-    def slack_alert(self):
-        pass

--- a/scripts/scale_test.py
+++ b/scripts/scale_test.py
@@ -1,0 +1,45 @@
+import random
+import time
+from locust import HttpUser, between, task, events
+
+random.seed(time.time())
+
+
+class WebsiteUser(HttpUser):
+    wait_time = between(1, 2)
+    project_urls = [
+        f"dp/v1/project/{p}"
+        for p in [
+            # Todo @mdunitz -- get project ids from database
+            "e7c47289-22fe-440e-ba24-a4434ac3f379",
+            "673637cf-dcb7-45e1-bb88-72a27c50c8ca",
+            "a55cac37-629f-4d28-9b3f-4ece7a7ac174",
+            "18e6337b-8c36-4977-9ac8-ca8aa5494481",
+            "8ad74eb4-c68f-4a4a-a17e-354f17605da6",
+        ]
+    ]
+
+    @task
+    def get_projects(self):
+        self.client.get("dp/v1/project")
+
+    @task
+    def get_project_info(self):
+        self.client.get(random.choice(self.project_urls))
+
+    @events.quitting.add_listener
+    def _(environment, **kw):
+        if environment.stats.total.fail_ratio > 0.01:
+            msg = "Test failed due to failure ratio > 1%"
+            environment.process_exit_code = 1
+        elif environment.stats.total.avg_response_time > 200:
+            msg = "Test failed due to average response time ratio > 200 ms"
+            environment.process_exit_code = 1
+        elif environment.stats.total.get_response_time_percentile(0.95) > 500:
+            msg = "Test failed due to 95th percentile response time > 500 ms"
+            environment.process_exit_code = 1
+        else:
+            environment.process_exit_code = 0
+
+    def slack_alert(self):
+        pass


### PR DESCRIPTION
## Need
- automated scale test to ensure latency remains low for dp api

## Approach
- create scheduled (weekly) github action that runs a 5 minute scale test and sends an aggregation of the results to slack

## Todo
- [ ] change SLACK_WEBHOOK in github secrets once single-cell-ops webhook is approved (currently sent to a channel I use for testing slack webhooks)
- [ ] add test for staging/prod once the cloudfront code is promoted 


![Screen Shot 2020-09-16 at 16 27 14](https://user-images.githubusercontent.com/7864111/93394251-8bc52980-f839-11ea-97ff-1267abb17de8.png)
