### PR TITLE
Point to cloudfront distribution of apis

### DIFF
--- a/frontend/src/configs/dev.js
+++ b/frontend/src/configs/dev.js
@@ -1,5 +1,5 @@
 const configs = {
-  API_URL: "https://api.dev.corpora.cziscience.com",
+  API_URL: "https://api.cellxgene.dev.single-cell.czi.technology/",
 };
 
 if (typeof module !== "undefined") module.exports = configs;

--- a/frontend/src/configs/staging.js
+++ b/frontend/src/configs/staging.js
@@ -1,5 +1,5 @@
 const configs = {
-  API_URL: "https://api.staging.corpora.cziscience.com",
+  API_URL: "https://api.cellxgene.staging.single-cell.czi.technology/",
 };
 
 if (typeof module !== "undefined") module.exports = configs;


### PR DESCRIPTION
## Need
- as a user I want data portal to load in under 1 second

## Approach
- we set up a cloudfront distribution to cache the api content this pr will point the data portal frontend at the cached version of the api

## Testing
- deployed to dev and saw a significant speed up in load time