### PR TITLE
thuang-621-dataset-column-fix

### DIFF
--- a/frontend/src/components/ProjectList/components/Dataset/style.ts
+++ b/frontend/src/components/ProjectList/components/Dataset/style.ts
@@ -20,6 +20,8 @@ export const Name = styled.div`
   align-items: center;
   line-height: 1.3;
   padding: 12px 0 12px 10px;
+  /* (thuang): width is ignored when flex is used */
+  min-width: 620px;
   max-width: 620px;
 `;
 

--- a/frontend/src/components/ProjectList/components/Heading/style.ts
+++ b/frontend/src/components/ProjectList/components/Heading/style.ts
@@ -17,6 +17,9 @@ export const Wrapper = styled.div`
 export const Name = styled.div`
   ${fontStyle}
   flex: ${LAYOUT.NAME};
+  /* (thuang): width is ignored when flex is used */
+  min-width: 620px;
+  max-width: 620px;
 `;
 
 export const QuestionMark = styled.img`


### PR DESCRIPTION
Looks like we just needed to add `min-width` and `max-width` as lower and upper bounds for `flex` CSS property!

The reason we can't just use `width: 620px;` is because `width` is ignored when `flex-basis` is set, in this case, `flex: 2` will automatically sets `flex-basis` to `auto`.

<img width="649" alt="Screen Shot 2020-09-30 at 5 29 07 PM" src="https://user-images.githubusercontent.com/6309723/94753235-79231800-0342-11eb-9a19-ee6b7887d235.png">

Resources:
1. https://mastery.games/post/the-difference-between-width-and-flex-basis/
2. https://css-tricks.com/snippets/css/a-guide-to-flexbox/

AFTER in Chrome:
<img width="1191" alt="Screen Shot 2020-09-30 at 5 19 25 PM" src="https://user-images.githubusercontent.com/6309723/94752805-2432d200-0341-11eb-9746-20c3c8c90cd1.png">


BEFORE and AFTER in Safari:
![gif](https://user-images.githubusercontent.com/6309723/94752773-09f8f400-0341-11eb-94bc-1872108c6015.gif)
