### PR TITLE
thuang-622-download-ux-fixes

### DIFF
--- a/frontend/gatsby-config.js
+++ b/frontend/gatsby-config.js
@@ -37,7 +37,7 @@ module.exports = {
     author: `Chan Zuckerberg Initiative`,
     description: `
     The cellxgene data portal is a repository of public, explorable single-cell datasets.
-    If you have a public dataset which you would like hosted for visualization on this site, please drop us a note at cellxgene@chanzuckerberg.com.
+    If you have a public dataset that you would like hosted on this site, please drop us a note at cellxgene@chanzuckerberg.com.
     `,
     title: `cellxgene`,
   },

--- a/frontend/src/components/ProjectList/components/Dataset/components/DownloadDataset/components/Content/components/CurlLink/style.ts
+++ b/frontend/src/components/ProjectList/components/Dataset/components/DownloadDataset/components/Content/components/CurlLink/style.ts
@@ -11,7 +11,7 @@ export const Code = styled.code`
   box-sizing: border-box;
   border-radius: 4px;
   height: 52px;
-  overflow: auto;
+  overflow: hidden;
   display: block;
   font-size: 13px;
   line-height: 18px;

--- a/frontend/src/components/ProjectList/components/Dataset/components/DownloadDataset/components/Content/components/DataFormat/index.tsx
+++ b/frontend/src/components/ProjectList/components/Dataset/components/DownloadDataset/components/Content/components/DataFormat/index.tsx
@@ -31,7 +31,7 @@ const DataFormat: FC<Props> = ({
         onChange={handleChange}
         selectedValue={format}
       >
-        <Radio label=".anndata" value={DATASET_ASSET_FORMAT.H5AD} />
+        <Radio label=".h5ad (AnnData v0.7)" value={DATASET_ASSET_FORMAT.H5AD} />
         <Radio label=".loom" value={DATASET_ASSET_FORMAT.LOOM} />
         <Radio label=".rds (Seurat v3)" value={DATASET_ASSET_FORMAT.RDS} />
       </RadioGroup>

--- a/frontend/src/components/ProjectList/components/Dataset/components/DownloadDataset/components/Content/components/Details/index.tsx
+++ b/frontend/src/components/ProjectList/components/Dataset/components/DownloadDataset/components/Content/components/Details/index.tsx
@@ -2,6 +2,9 @@ import React, { FC } from "react";
 import { Section, Text, Title } from "../common/style";
 import { Spinner } from "./style";
 
+export const PROMPT_TEXT =
+  "Select one of the data formats to view its download details.";
+
 interface Props {
   selected: boolean;
   fileSize: number;
@@ -21,7 +24,7 @@ const Details: FC<Props> = ({
     }
 
     if (!selected) {
-      return "Select from an above data format to view download details.";
+      return PROMPT_TEXT;
     }
 
     return `${Math.floor(fileSize / MEGA_BYTES)}MB`;

--- a/frontend/src/components/ProjectList/index.tsx
+++ b/frontend/src/components/ProjectList/index.tsx
@@ -15,8 +15,8 @@ const ProjectsList: FC<Props> = ({ projects }) => {
       <h1>Datasets</h1>
       <p>
         The cellxgene data portal is a repository of public, explorable
-        single-cell datasets. If you have a public dataset which you would like
-        hosted for visualization on this site, please let us know at{" "}
+        single-cell datasets. If you have a public dataset that you would like
+        hosted on this site, please let us know at{" "}
         <a href="mailto:cellxgene@chanzuckerberg.com">
           cellxgene@chanzuckerberg.com
         </a>

--- a/frontend/tests/features/homepage.test.ts
+++ b/frontend/tests/features/homepage.test.ts
@@ -1,3 +1,4 @@
+import { PROMPT_TEXT } from "src/components/ProjectList/components/Dataset/components/DownloadDataset/components/Content/components/Details";
 import { goToPage } from "tests/utils/helpers";
 import { TEST_URL } from "../common/constants";
 import { getTestTag, getText } from "../utils/selectors";
@@ -36,14 +37,12 @@ describe("Homepage", () => {
       ).toBeTruthy();
 
       await expect(page).toHaveSelector(getText("DATA FORMAT"));
-      await expect(page).toHaveSelector(getText(".anndata"));
+      await expect(page).toHaveSelector(getText(".h5ad (AnnData v0.7)"));
       await expect(page).toHaveSelector(getText(".loom"));
       await expect(page).toHaveSelector(getText(".rds (Seurat v3)"));
 
       await expect(page).toHaveSelector(getText("DOWNLOAD DETAILS"));
-      await expect(page).toHaveSelector(
-        getText("Select from an above data format to view download details.")
-      );
+      await expect(page).toHaveSelector(getText(PROMPT_TEXT));
     });
 
     it("downloads a file", async () => {
@@ -51,7 +50,7 @@ describe("Homepage", () => {
 
       await page.click(getTestTag(DATASET_ROW_DOWNLOAD_BUTTON_ID));
 
-      await page.click(getText(".anndata"));
+      await page.click(getText(".h5ad (AnnData v0.7)"));
 
       const downloadLink = await page.getAttribute(
         getTestTag("download-asset-download-button"),


### PR DESCRIPTION
Ticket: https://app.zenhub.com/workspaces/single-cell-5e2a191dad828d52cc78b028/issues/chanzuckerberg/corpora-data-portal/622

QA checks:

1. Hide scroll bar in Chrome, FF, and Safari
1. Change download prompt text to: Select one of the data formats to view its download details
1. Update .anndata to .h5ad (AnnData v0.7)
1. Update Data Portal description to:

> The cellxgene data portal is a repository of public, explorable single-cell datasets. If you have a public dataset that you would like hosted on this site, please let us know at cellxgene@chanzuckerberg.com.

Thank you!

Proof:

<img width="742" alt="Screen Shot 2020-10-01 at 11 29 07 AM" src="https://user-images.githubusercontent.com/6309723/94850683-24cc7680-03dc-11eb-951f-8d459f3811a7.png">
<img width="1402" alt="Screen Shot 2020-10-01 at 11 30 55 AM" src="https://user-images.githubusercontent.com/6309723/94850694-27c76700-03dc-11eb-999f-513d7a73b1ad.png">
<img width="690" alt="Screen Shot 2020-10-01 at 11 31 47 AM" src="https://user-images.githubusercontent.com/6309723/94850711-2eee7500-03dc-11eb-86be-2ac35f2a0c1b.png">
