### PR TITLE
fix FE collection runtime error

### DIFF
--- a/frontend/src/components/Collections/components/Collection/index.tsx
+++ b/frontend/src/components/Collections/components/Collection/index.tsx
@@ -9,9 +9,11 @@ interface Props {
 const Collection: FC<Props> = ({ id }) => {
   const { data: collection } = useCollection(id);
 
+  if (!collection?.datasets) return null;
+
   return (
     <>
-      {collection?.datasets
+      {collection.datasets
         .map((dataset) => ({
           dataset,
           links: collection.links,


### PR DESCRIPTION
Doing a better response check to avoid runtime error! 

I forgot BE would return error response like the following, so I need to update how I check for empty datasets:

```ts
{
  detail: "None is not of type 'string'↵↵Failed validating 'type' in schema['properties']['obfuscated_uuid']:↵    {'type': 'string'}↵↵On instance['obfuscated_uuid']:↵    None",
  status: 500,
  title: "Response body does not conform to specification",
  type: "about:blank"
}
```

Thank you!

<img width="1771" alt="Screen Shot 2020-11-02 at 10 23 43 AM" src="https://user-images.githubusercontent.com/6309723/97904835-ec2efe00-1cf5-11eb-97d6-7f1997c35c08.png">
