### PR TITLE
allow empty fields

### DIFF
--- a/backend/config/corpora-api.yml
+++ b/backend/config/corpora-api.yml
@@ -630,8 +630,10 @@ components:
           nullable: true
         contact_name:
           type: string
+          nullable: true
         contact_email:
           type: string
+          nullable: true
         data_submission_policy_version:
           type: string
         datasets:


### PR DESCRIPTION
due to migration, there are empty fields that are returned. Changing the openapi spec to accommodate these empty fields.