### PR TITLE
thuang-651-part2

### DIFF
--- a/frontend/src/common/queries/collections.ts
+++ b/frontend/src/common/queries/collections.ts
@@ -40,7 +40,7 @@ export function useCollection(id: string) {
   return useQuery<Collection>([USE_COLLECTION, id], fetchCollection);
 }
 
-export async function createCollection(payload: string): Promise<string> {
+export async function createCollection(): Promise<string> {
   // DEBUG
   // DEBUG
   // DEBUG
@@ -50,25 +50,7 @@ export async function createCollection(payload: string): Promise<string> {
     }, 2 * 1000);
   });
 
-  // DEBUG
-  // DEBUG
-  // DEBUG
-  return "2";
-
-  // DEBUG
-  // DEBUG
-  // DEBUG
-  // const json = await (
-  //   await fetch(API_URL + API.CREATE_COLLECTION, {
-  //     body: payload,
-  //     headers: {
-  //       "Content-Type": "application/json",
-  //     },
-  //     method: "POST",
-  //   })
-  // ).json();
-
-  // return json.collection_uuid;
+  return "673637cf-dcb7-45e1-bb88-72a27c50c8ca";
 }
 
 export const formDataToObject = function (formData: FormData) {

--- a/frontend/src/components/Collections/components/Collection/index.tsx
+++ b/frontend/src/components/Collections/components/Collection/index.tsx
@@ -9,11 +9,6 @@ interface Props {
 const Collection: FC<Props> = ({ id }) => {
   const { data: collection } = useCollection(id);
 
-  // DEBUG
-  // DEBUG
-  // DEBUG
-  console.log(">>>>>>>>>>> collection", collection);
-
   if (!collection?.datasets) return null;
 
   return (

--- a/frontend/src/components/Collections/index.tsx
+++ b/frontend/src/components/Collections/index.tsx
@@ -8,11 +8,6 @@ import { TitleWrapper } from "./style";
 const Collections: FC = () => {
   const { isFetching, data: collections } = useCollections();
 
-  // DEBUG
-  // DEBUG
-  // DEBUG
-  console.log("----collections", collections);
-
   if (isFetching && !collections) return <div>Loading collections...</div>;
 
   if (!collections) return <div>Sorry, we could not find any collections</div>;

--- a/frontend/src/components/CreateCollectionModal/components/Content/index.tsx
+++ b/frontend/src/components/CreateCollectionModal/components/Content/index.tsx
@@ -17,6 +17,8 @@ import LinkInput, { LinkValue, TYPES } from "./components/LinkInput";
 import Policy from "./components/Policy";
 import { ContactWrapper, Form, StyledInput } from "./style";
 
+const POLICY_PAYLOAD_KEY = "data_submission_policy_version";
+
 interface Props {
   onClose: () => void;
 }
@@ -52,9 +54,7 @@ const Content: FC<Props> = (props) => {
 
   const formEl = useRef<HTMLFormElement>(null);
 
-  const [links, setLinks] = useState<Link[]>([
-    { id: Date.now(), isValid: false, type: TYPES.DOI, url: "" },
-  ]);
+  const [links, setLinks] = useState<Link[]>([]);
 
   const queryCache = useQueryCache();
 
@@ -72,14 +72,6 @@ const Content: FC<Props> = (props) => {
     const isPolicyChecked = policyVersion !== "";
 
     const result = areLinksValid && areFieldsValid && isPolicyChecked;
-
-    // DEBUG
-    // DEBUG
-    // DEBUG
-    console.log("areLinksValid", areLinksValid);
-    console.log("areFieldsValid", areFieldsValid);
-    console.log("isPolicyChecked", isPolicyChecked);
-    console.log("result", result);
 
     if (result !== isValid) {
       setIsValid(result);
@@ -132,6 +124,12 @@ const Content: FC<Props> = (props) => {
           <Policy handleChange={handlePolicyChange} />
         </Form>
       </div>
+      <Footer />
+    </>
+  );
+
+  function Footer() {
+    return (
       <div className={Classes.DIALOG_FOOTER}>
         <div className={Classes.DIALOG_FOOTER_ACTIONS}>
           <Button
@@ -152,14 +150,10 @@ const Content: FC<Props> = (props) => {
           </Button>
         </div>
       </div>
-    </>
-  );
+    );
+  }
 
   async function onSubmit() {
-    // payload add links
-    // mutate(JSON.string(payload))
-    // set collectionId and redirect
-
     if (!formEl?.current) return;
 
     const formData = new FormData(formEl.current);
@@ -169,22 +163,11 @@ const Content: FC<Props> = (props) => {
     const payloadLinks = links.map(({ type, url }) => ({ type, url }));
 
     payload.links = payloadLinks;
-    payload["data_submission_policy_version"] = policyVersion;
-
-    // DEBUG
-    // DEBUG
-    // DEBUG
-    console.log("---payload", payload);
-    console.log("---JSON.stringify(payload)", JSON.stringify(payload));
+    payload[POLICY_PAYLOAD_KEY] = policyVersion;
 
     setIsLoading(true);
 
-    const collectionId = (await mutate(JSON.stringify(payload))) as string;
-
-    // DEBUG
-    // DEBUG
-    // DEBUG
-    console.log("---------collectionId", collectionId);
+    const collectionId = (await mutate()) as string;
 
     setIsLoading(false);
 
@@ -216,11 +199,6 @@ const Content: FC<Props> = (props) => {
 
     const newLinks = [...links];
     newLinks[index] = newLink;
-
-    // DEBUG
-    // DEBUG
-    // DEBUG
-    console.log("--------newLinks", newLinks);
 
     setLinks(newLinks);
   }

--- a/frontend/src/components/CreateCollectionModal/index.tsx
+++ b/frontend/src/components/CreateCollectionModal/index.tsx
@@ -1,10 +1,17 @@
 import { Dialog } from "@blueprintjs/core";
+import loadable from "@loadable/component";
 import React, { FC, useState } from "react";
 import { get } from "src/common/featureFlags";
 import { FEATURES } from "src/common/featureFlags/features";
 import { BOOLEAN } from "src/common/localStorage/set";
-import Content from "./components/Content";
 import { StyledButton } from "./style";
+
+const AsyncContent = loadable(
+  () =>
+    /*webpackChunkName: 'CreateCollectionModalContent' */ import(
+      "./components/Content"
+    )
+);
 
 const CreateCollection: FC = () => {
   const [isOpen, setIsOpen] = useState(false);
@@ -15,14 +22,19 @@ const CreateCollection: FC = () => {
 
   return (
     <>
-      <StyledButton onClick={toggleOpen}>Create Collection</StyledButton>
+      <StyledButton
+        onMouseOver={() => AsyncContent.preload()}
+        onClick={toggleOpen}
+      >
+        Create Collection
+      </StyledButton>
       <Dialog
         isOpen={isOpen}
         onClose={toggleOpen}
         canEscapeKeyClose={false}
         canOutsideClickClose={false}
       >
-        <Content onClose={toggleOpen} />
+        {isOpen && <AsyncContent onClose={toggleOpen} />}
       </Dialog>
     </>
   );


### PR DESCRIPTION





Changelog from `thuang-651-part2`:
1. Hard code an existing POST response, since BE endpoint is WIP `frontend/src/common/queries/collections.ts`
1. Code split Create Collection modal's Content component to only download the component when the button is hovered

Changelog from `thuang-651-create-collection-component`:
1. Add `gatsby-plugin-sass` to allow Blueprint.js scss overwrite
1. Add `@blueprintjs/icons`
1. Add `lodash-es` for ES6 module version of lodash, which is tree shaking friendly and, in theory, reduces js bundle size
1. Introduce @hthomas-czi 's design system by adding standardized colors in `frontend/src/components/common/theme.ts` and Blueprint style overwrite in `frontend/src/global.scss`
1. Add `CreateCollectionModal`, which is hidden behind URL param feature flag: `?cc=true` 
1. Build common `Form` components in `frontend/src/components/common/Form`, which allows us to do sync validation and show error when requirement is not met. This includes `Input` and `TextArea` components
1. Add policy attestation where we hard code policy version in the FE

QA steps:
1. Please pull branch `thuang-651-part2`
2. Run `npm i && npm start`
3. Visit: `http://localhost:8000/?cc=true`
4. You should see "Create Collection" button on the upper right corner
5. Play with the form and see if anything is weird for you
6. Currently we hard code POST response to redirect to an existing collection, since BE endpoint is WIP

Form:
<img width="701" alt="Screen Shot 2020-11-04 at 2 42 23 PM" src="https://user-images.githubusercontent.com/6309723/98175761-10ccd680-1eac-11eb-8e66-df6e10a1229a.png">

Error state:
<img width="753" alt="Screen Shot 2020-11-04 at 2 41 31 PM" src="https://user-images.githubusercontent.com/6309723/98175739-07436e80-1eac-11eb-8927-49d65633dd22.png">

Demo:
![gif](https://user-images.githubusercontent.com/6309723/98175623-c9464a80-1eab-11eb-935b-a8710c90c573.gif)

Thank you!!