### PR TITLE
Pin nodejs to version 14

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.8'
 
 services:
   database:
-    image: postgres
+    image: postgres:13.0
     ports:
       - "5432:5432"
     environment:
@@ -70,7 +70,7 @@ services:
       - ./backend/corpora:/corpora-data-portal/backend/chalice/api_server/chalicelib/corpora
       - ./backend/config:/corpora-data-portal/backend/chalice/api_server/chalicelib/config
   oidc:
-    image: soluto/oidc-server-mock
+    image: soluto/oidc-server-mock:0.3.0
     ports:
       - "4011:80"
       - "8443:443"

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -14,7 +14,7 @@ WORKDIR /opt/node_app
 # -- TODO, we should try turning this back on later.
 # USER node
 COPY package.json package-lock.json* ./
-RUN npm install --verbose -no-optional && npm cache clean --force
+RUN npm install --verbose --no-optional && npm cache clean --force
 ENV PATH /opt/node_app/node_modules/.bin:$PATH
 
 # -- TODO, we should try turning this back on later.

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,5 +1,5 @@
 # Frontend dockerfile
-FROM node
+FROM node:14
 
 # install dependencies first, in a different location for easier app bind mounting for local development
 # due to default /opt permissions we have to create the dir with root and change perms
@@ -14,7 +14,7 @@ WORKDIR /opt/node_app
 # -- TODO, we should try turning this back on later.
 # USER node
 COPY package.json package-lock.json* ./
-RUN npm install --no-optional && npm cache clean --force
+RUN npm install --verbose -no-optional && npm cache clean --force
 ENV PATH /opt/node_app/node_modules/.bin:$PATH
 
 # -- TODO, we should try turning this back on later.


### PR DESCRIPTION
NPM in the nodejs:15 docker image has a bug that causes it to OOM. This should fix problems with launching the local dev environment using `make dev-init`