### PR TITLE
thuang-update-dev-API-url

### DIFF
--- a/frontend/src/configs/dev.js
+++ b/frontend/src/configs/dev.js
@@ -1,5 +1,5 @@
 const configs = {
-  API_URL: "https://api.cellxgene.dev.single-cell.czi.technology/",
+  API_URL: "https://api.cellxgene.dev.single-cell.czi.technology",
 };
 
 if (typeof module !== "undefined") module.exports = configs;


### PR DESCRIPTION
Seems like we need to remove the `/` at the end of the API URL, otherwise we get `//` in the API request! E.g., 

<img width="997" alt="Screen Shot 2020-11-12 at 11 06 34 AM" src="https://user-images.githubusercontent.com/6309723/98984534-3030b880-24d7-11eb-90ae-4cb76b474907.png">

This somehow prevents Auth cookies from being sent to BE on Dev now

PTAL thank you!