### PR TITLE
thuang-create-collection-integration

### DIFF
--- a/frontend/src/common/utils/getUrlHost.ts
+++ b/frontend/src/common/utils/getUrlHost.ts
@@ -1,0 +1,8 @@
+export function getUrlHost(url: string): string | null {
+  try {
+    const result = new URL(url);
+    return result.host;
+  } catch {
+    return null;
+  }
+}

--- a/frontend/src/components/Collections/components/Collection/index.tsx
+++ b/frontend/src/components/Collections/components/Collection/index.tsx
@@ -1,13 +1,14 @@
 import React, { FC } from "react";
-import { useCollection } from "src/common/queries/collections";
+import { useCollection, VISIBILITY } from "src/common/queries/collections";
 import Dataset from "../Dataset";
 
 interface Props {
   id: string;
+  visibility: VISIBILITY;
 }
 
-const Collection: FC<Props> = ({ id }) => {
-  const { data: collection } = useCollection(id);
+const Collection: FC<Props> = ({ id, visibility }) => {
+  const { data: collection } = useCollection(id, visibility);
 
   if (!collection?.datasets) return null;
 

--- a/frontend/src/components/Collections/components/Dataset/components/MoreInformation/index.tsx
+++ b/frontend/src/components/Collections/components/Dataset/components/MoreInformation/index.tsx
@@ -1,5 +1,6 @@
 import React, { FC } from "react";
 import { Collection } from "src/common/entities";
+import { getUrlHost } from "src/common/utils/getUrlHost";
 import { SmallColumn } from "../../common/style";
 import { StyledAnchor, Wrapper } from "./style";
 interface AnchorProps {
@@ -20,22 +21,25 @@ interface Props {
 
 const MoreInformation: FC<Props> = ({ links }) => {
   const uniqueLinks = Array.from(
-    new Map(links.map((link) => [link.link_url, link.link_name]))
+    // eslint-disable-next-line @typescript-eslint/camelcase
+    new Map(links.map(({ link_url, link_name }) => [link_url, link_name]))
   );
 
   const styledLinks = uniqueLinks.map((link, index) => {
     const [url, name] = link;
 
+    const displayName = name || getUrlHost(url);
+
     if (index === uniqueLinks.length - 1) {
       return (
-        <div key={`${name}${url}`}>
-          <Anchor url={url}>{name}</Anchor>
+        <div key={url}>
+          <Anchor url={url}>{displayName}</Anchor>
         </div>
       );
     } else {
       return (
-        <div key={`${name}${url}`}>
-          <Anchor url={url}>{name},&nbsp;</Anchor>
+        <div key={url}>
+          <Anchor url={url}>{displayName},&nbsp;</Anchor>
         </div>
       );
     }

--- a/frontend/src/components/Collections/index.tsx
+++ b/frontend/src/components/Collections/index.tsx
@@ -28,8 +28,8 @@ const Collections: FC = () => {
         .
       </p>
       <Heading />
-      {collections?.map((collection) => (
-        <Collection id={collection.id} key={collection.id} />
+      {collections?.map(({ id, visibility }) => (
+        <Collection id={id} visibility={visibility} key={id} />
       ))}
     </>
   );

--- a/frontend/src/components/CreateCollectionModal/components/Content/common/constants.ts
+++ b/frontend/src/components/CreateCollectionModal/components/Content/common/constants.ts
@@ -1,1 +1,1 @@
-export const DEBOUNCE_TIME_MS = 200;
+export const DEBOUNCE_TIME_MS = 100;

--- a/frontend/src/components/CreateCollectionModal/components/Content/index.tsx
+++ b/frontend/src/components/CreateCollectionModal/components/Content/index.tsx
@@ -1,13 +1,11 @@
 import { Button, Classes, Intent } from "@blueprintjs/core";
 import { useNavigate } from "@reach/router";
 import React, { FC, useEffect, useRef, useState } from "react";
-import { useMutation, useQueryCache } from "react-query";
 import { ROUTES } from "src/common/constants/routes";
 import { COLLECTION_LINK_TYPE } from "src/common/entities";
 import {
-  createCollection,
   formDataToObject,
-  USE_COLLECTIONS,
+  useCreateCollection,
 } from "src/common/queries/collections";
 import { Value } from "src/components/common/Form/common/constants";
 import Input from "src/components/common/Form/Input";
@@ -59,13 +57,7 @@ const Content: FC<Props> = (props) => {
 
   const [links, setLinks] = useState<Link[]>([]);
 
-  const queryCache = useQueryCache();
-
-  const [mutate] = useMutation(createCollection, {
-    onSuccess: () => {
-      queryCache.invalidateQueries(USE_COLLECTIONS);
-    },
-  });
+  const [mutate] = useCreateCollection();
 
   useEffect(() => {
     const areLinksValid = links.every((link) => link.isValid);
@@ -179,11 +171,13 @@ const Content: FC<Props> = (props) => {
 
     setIsLoading(true);
 
-    const collectionId = (await mutate()) as string;
+    const collectionId = (await mutate(JSON.stringify(payload))) as string;
 
     setIsLoading(false);
 
-    navigate(ROUTES.PRIVATE_COLLECTION.replace(":id", collectionId));
+    if (collectionId) {
+      navigate(ROUTES.PRIVATE_COLLECTION.replace(":id", collectionId));
+    }
   }
 
   function handleInputChange({ isValid: isValidFromInput, name }: Value) {

--- a/frontend/src/views/Collection/index.tsx
+++ b/frontend/src/views/Collection/index.tsx
@@ -2,7 +2,8 @@ import { Button, Classes, H3, H4, Intent, UL } from "@blueprintjs/core";
 import { RouteComponentProps } from "@reach/router";
 import React, { FC } from "react";
 import { COLLECTION_LINK_TYPE_OPTIONS, Link } from "src/common/entities";
-import { useCollection } from "src/common/queries/collections";
+import { useCollection, VISIBILITY } from "src/common/queries/collections";
+import { getUrlHost } from "src/common/utils/getUrlHost";
 import {
   CenterAlignedDiv,
   CollectionInfo,
@@ -21,18 +22,6 @@ interface RouteProps {
 }
 
 export type Props = RouteComponentProps<RouteProps>;
-
-const getDomain = (url: string): string | null => {
-  let result;
-
-  try {
-    result = new URL(url);
-  } catch {
-    return null;
-  }
-
-  return result.host;
-};
 
 const RenderEmptyDatasets = () => {
   return (
@@ -66,24 +55,30 @@ const renderLinks = (links: Link[]) => {
 
     if (!linkTypeOption) return null;
 
-    const domain = getDomain(url);
+    const urlHost = getUrlHost(url);
 
     const { text } = linkTypeOption;
 
-    if (!domain) return null;
+    if (!urlHost) return null;
 
     return (
       <React.Fragment key={`${type}+${url}`}>
         <span className={Classes.TEXT_MUTED}>{text}</span>
-        <StyledLink href={url}>{domain}</StyledLink>
+        <StyledLink href={url}>{urlHost}</StyledLink>
       </React.Fragment>
     );
   });
 };
 
 const Collection: FC<Props> = ({ id }) => {
-  const { data: collection } = useCollection(id ?? "");
-  if (!collection) return null;
+  const isPrivate = window.location.pathname.includes("/private");
+
+  const { data: collection, isError } = useCollection(
+    id ?? "",
+    isPrivate ? VISIBILITY.PRIVATE : VISIBILITY.PUBLIC
+  );
+
+  if (!collection || isError) return null;
 
   return (
     <ViewGrid>


### PR DESCRIPTION
1. Updates collection link object keys to add `link_` prefix
1. Adds link name display support to fall back to showing the URL host when `link_name` is not available.
1. Create collection flow now works end to end!

QA Steps:
1. Pull the branch `thuang-create-collection-integration`
1. Make sure your `frontend/src/configs/configs.js` points to Dev: `API_URL: "https://api.cellxgene.dev.single-cell.czi.technology",`
1. Make sure you use Requestly Chrome Extension to hard code your `cxguser` and `session` cookies from Dev env
1. Fire up `npm start`
1. Navigate to `http://localhost:8000/?auth=true&cc=true`
1. Click on "Create Collection" button
1. Fill in the form
1. Click "Create"
1. You should now land on your newly created private collection page!

NOTE: You might be able to get this to work via `make local-init` and `make local-start`, but I haven't tested that yet lol

Screenshot below simulates the case what users will see when `link_name` is not available!
<img width="1376" alt="Screen Shot 2020-11-13 at 1 11 30 PM" src="https://user-images.githubusercontent.com/6309723/99121820-f84a7380-25b1-11eb-94c1-53791a0785fb.png">

![demo](https://user-images.githubusercontent.com/6309723/99316216-cdae2400-2818-11eb-9a8f-862bafed1fe1.gif)

PTAL thank you!

resolves #663 