### PR TITLE
Improve the mock oauth server tests

### DIFF
--- a/backend/corpora/lambdas/api/v1/authentication.py
+++ b/backend/corpora/lambdas/api/v1/authentication.py
@@ -80,7 +80,7 @@ def oauth2_callback() -> Response:
         # write the cookie
         save_token(config.cookie_name, token)
     except Exception as e:
-        current_app.logger.warning(f"Unable to authorize access token: {str(e)}: {str(token)}")
+        current_app.logger.warning(f"Unable to authorize access token: {str(e)}")
         # remove the token
         remove_token(config.cookie_name)
         raise UnauthorizedError("response from oauth server not valid")

--- a/tests/unit/backend/chalice/api_server/mock_auth.py
+++ b/tests/unit/backend/chalice/api_server/mock_auth.py
@@ -1,75 +1,97 @@
-import random
 import urllib
-
 import jose.jwt
 import time
-
+import random
+import sys
+import requests
 from flask import Flask, request, redirect, make_response, jsonify
-
-# Create a mocked out oauth server, which servers all the endpoints needed by the oauth type.
-mock_oauth_app = Flask("mock_oauth_app")
-
-# The port that the mock oauth server will listen on
-PORT = random.randint(10000, 12000)
+import subprocess
 
 # seconds until the token expires
 TOKEN_EXPIRES = 2
 
 
-@mock_oauth_app.route("/authorize")
-def authorize():
-    callback = request.args.get("redirect_uri")
-    state = request.args.get("state")
-    return redirect(callback + f"?code=fakecode&state={state}")
+# A mocked out oauth server, which serves all the endpoints needed by the oauth type.
+class MockOauthApp:
+    def __init__(self, port):
+        self.port = port
+
+        # mock flask app
+        self.app = Flask("mock_oauth_app")
+
+        self.app.add_url_rule("/authorize", view_func=self.api_authorize)
+        self.app.add_url_rule("/oauth/token", view_func=self.api_oauth_token, methods=["POST"])
+        self.app.add_url_rule("/v2/logout", view_func=self.api_logout)
+        self.app.add_url_rule("/.well-known/openid-configuration", view_func=self.api_openid_configuration)
+        self.app.add_url_rule("/.well-known/jwks.json", view_func=self.api_jwks)
+
+    def api_authorize(self):
+        callback = request.args.get("redirect_uri")
+        state = request.args.get("state")
+        return redirect(callback + f"?code=fakecode&state={state}")
+
+    def api_oauth_token(self):
+        expires_at = time.time()
+        headers = dict(alg="RS256", kid="fake_kid")
+        payload = dict(
+            name="Fake User", sub="test_user_id", email="fake_user@email.com", email_verified=True, exp=expires_at
+        )
+
+        jwt = jose.jwt.encode(claims=payload, key="mysecret", algorithm="HS256", headers=headers)
+        r = {
+            "access_token": f"access-{time.time()}",
+            "id_token": jwt,
+            "refresh_token": f"random-{time.time()}",
+            "scope": "openid profile email offline",
+            "expires_in": TOKEN_EXPIRES,
+            "token_type": "Bearer",
+            "expires_at": expires_at,
+        }
+        return make_response(jsonify(r))
+
+    def api_logout(self):
+        return_to = request.args.get("returnTo")
+        return redirect(return_to)
+
+    def api_openid_configuration(self):
+        data = dict(jwks_uri=f"http://localhost:{self.port}/.well-known/jwks.json")
+        return make_response(jsonify(data))
+
+    def api_jwks(self):
+        data = dict(
+            alg="RS256",
+            kty="RSA",
+            use="sig",
+            kid="fake_kid",
+        )
+        return make_response(jsonify(dict(keys=[data])))
 
 
-@mock_oauth_app.route("/oauth/token", methods=["POST"])
-def token():
-    expires_at = time.time()
-    headers = dict(alg="RS256", kid="fake_kid")
-    payload = dict(
-        name="Fake User", sub="test_user_id", email="fake_user@email.com", email_verified=True, exp=expires_at
-    )
+class MockOauthServer:
+    def __init__(self):
+        self.process = None
+        self.port = None
+        self.server_okay = False
 
-    jwt = jose.jwt.encode(claims=payload, key="mysecret", algorithm="HS256", headers=headers)
-    r = {
-        "access_token": f"access-{time.time()}",
-        "id_token": jwt,
-        "refresh_token": f"random-{time.time()}",
-        "scope": "openid profile email offline",
-        "expires_in": TOKEN_EXPIRES,
-        "token_type": "Bearer",
-        "expires_at": expires_at,
-    }
-    return make_response(jsonify(r))
+    def start(self):
+        self.port = random.randint(10000, 20000)
+        self.process = subprocess.Popen([sys.executable, __file__, str(self.port)])
+        # Verify that the mock oauth server is ready (accepting requests) before starting the tests.
+        self.server_okay = False
+        for _ in range(5):
+            try:
+                response = requests.get(f"http://localhost:{self.port}/.well-known/jwks.json")
+                if response.status_code == 200:
+                    self.server_okay = True
+                    break
+            except Exception:
+                pass
 
+            # wait one second and try again
+            time.sleep(1)
 
-@mock_oauth_app.route("/v2/logout")
-def logout():
-    return_to = request.args.get("returnTo")
-    return redirect(return_to)
-
-
-@mock_oauth_app.route("/.well-known/openid-configuration")
-def openid_configuration():
-    data = dict(jwks_uri=f"http://localhost:{PORT}/.well-known/jwks.json")
-    return make_response(jsonify(data))
-
-
-@mock_oauth_app.route("/.well-known/jwks.json")
-def jwks():
-    data = dict(
-        alg="RS256",
-        kty="RSA",
-        use="sig",
-        kid="fake_kid",
-    )
-    return make_response(jsonify(dict(keys=[data])))
-
-
-# function to launch the mock oauth server
-def launch_mock_oauth():
-    mock_oauth_app.run(port=PORT)
+    def terminate(self):
+        self.process.terminate()
 
 
 def get_auth_token(app):
@@ -88,3 +110,9 @@ def get_auth_token(app):
     url = f"/dp/v1/oauth2/callback?code=fakecode&state={args['state']}"
     response = app.get(url, headers=dict(host="localhost", Cookie=response.headers["Set-Cookie"]))
     return response.headers["Set-Cookie"]
+
+
+if __name__ == "__main__":
+    port = int(sys.argv[1])
+    mock_app = MockOauthApp(port)
+    mock_app.app.run(port=port, debug=True)

--- a/tests/unit/backend/chalice/api_server/test_v1_collection.py
+++ b/tests/unit/backend/chalice/api_server/test_v1_collection.py
@@ -6,37 +6,36 @@ import unittest
 from datetime import datetime
 
 from furl import furl
-from multiprocessing import Process
 
 from backend.corpora.common.corpora_orm import CollectionVisibility
 from backend.corpora.common.entities import Collection
 from tests.unit.backend.chalice.api_server import BaseAPITest
 from tests.unit.backend.utils import BogusCollectionParams
-from tests.unit.backend.chalice.api_server.mock_auth import PORT, launch_mock_oauth, get_auth_token
+from tests.unit.backend.chalice.api_server.mock_auth import MockOauthServer, get_auth_token
 
 
 class TestCollection(BaseAPITest, unittest.TestCase):
-    def setUp(self):
-        self.mock_oauth_process = Process(target=launch_mock_oauth)
-        self.mock_oauth_process.start()
+    @classmethod
+    def setUpClass(cls):
+        BaseAPITest.setUpClass()
+        cls.mock_oauth_server = MockOauthServer()
+        cls.mock_oauth_server.start()
+        assert cls.mock_oauth_server.server_okay
 
-        old_path = sys.path.copy()
-
-        def restore_path(p):
-            sys.path = p
-
-        sys.path.insert(0, os.path.join(self.corpora_api_dir, "chalicelib"))  # noqa
-        self.addCleanup(restore_path, old_path)
+        cls.old_path = sys.path.copy()
+        sys.path.insert(0, os.path.join(cls.corpora_api_dir, "chalicelib"))  # noqa
         from corpora.common.corpora_config import CorporaAuthConfig
 
         # Use the CorporaAuthConfig used by the chalice app
-        self.auth_config = CorporaAuthConfig()
-        self.auth_config._config["api_base_url"] = f"http://localhost:{PORT}"
-        self.auth_config._config["callback_base_url"] = "http://localhost:5000"
-        self.auth_config.update_defaults()
+        cls.auth_config = CorporaAuthConfig()
+        cls.auth_config._config["api_base_url"] = f"http://localhost:{cls.mock_oauth_server.port}"
+        cls.auth_config._config["callback_base_url"] = "http://localhost:5000"
+        cls.auth_config.update_defaults()
 
-    def tearDown(self):
-        self.mock_oauth_process.terminate()
+    @classmethod
+    def tearDownClass(cls):
+        cls.mock_oauth_server.terminate()
+        sys.path = cls.old_path
 
     def validate_collections_response_structure(self, body):
         self.assertIn("collections", body)


### PR DESCRIPTION
It can now be used simultaneously by multiple tests, and the
port used by the mock server can be immediately reused.
This should avoid the flaky tests.

 #719