### PR TITLE
thuang-517-AuthN-bugfix

### DIFF
--- a/frontend/src/components/CreateCollectionModal/index.tsx
+++ b/frontend/src/components/CreateCollectionModal/index.tsx
@@ -34,7 +34,6 @@ const CreateCollection: FC = () => {
         canEscapeKeyClose: false,
         canOutsideClickClose: false,
         content: AsyncContent,
-        isCloseButtonShown: false,
       }
     : {
         canEscapeKeyClose: true,

--- a/frontend/src/components/Header/components/AuthButtons/index.tsx
+++ b/frontend/src/components/Header/components/AuthButtons/index.tsx
@@ -19,7 +19,12 @@ import { ButtonWrapper, Initial } from "./style";
 const AuthButtons = () => {
   const hasAuth = get(FEATURES.AUTH) === BOOLEAN.TRUE;
 
-  const { data: userInfo, isLoading } = useUserInfo(hasAuth);
+  const { data: userInfo, isLoading, error } = useUserInfo(hasAuth);
+
+  if (userInfo && error) {
+    // (thuang): Force refresh page to log user out
+    window.location.reload();
+  }
 
   if (!hasAuth || isLoading) return null;
 


### PR DESCRIPTION
This PR fixes the edge case where a user logs out from another tab, the current tab will still be logged in

The issue was that React Query caches the successful response, so even if subsequent calls fail (since the user has logged out from another tab) React Query will still return cached successful response.

The solution is to detect when there's both `userInfo` and `error`, and force refresh the page to log the user out!

closes #517 