### PR TITLE
auth to collection creation flow

### DIFF
--- a/frontend/src/common/constants/queryParameters.ts
+++ b/frontend/src/common/constants/queryParameters.ts
@@ -1,0 +1,3 @@
+export enum QUERY_PARAMETERS {
+  LOGIN_MODULE_REDIRECT = "showCCModule",
+}

--- a/frontend/src/components/CreateCollectionModal/components/CTA/index.tsx
+++ b/frontend/src/components/CreateCollectionModal/components/CTA/index.tsx
@@ -1,6 +1,7 @@
 import { AnchorButton, Button, Classes, Intent } from "@blueprintjs/core";
 import React, { FC } from "react";
 import { API } from "src/common/API";
+import { QUERY_PARAMETERS } from "src/common/constants/queryParameters";
 import { API_URL } from "src/configs/configs";
 import { ContentWrapper } from "./style";
 
@@ -27,7 +28,7 @@ const CTA: FC<Props> = ({ onClose }) => {
           </Button>
           <AnchorButton
             intent={Intent.PRIMARY}
-            href={`${API_URL}${API.LOG_IN}`}
+            href={`${API_URL}${API.LOG_IN}?redirect=?${QUERY_PARAMETERS.LOGIN_MODULE_REDIRECT}`}
           >
             Continue
           </AnchorButton>

--- a/frontend/src/components/CreateCollectionModal/index.tsx
+++ b/frontend/src/components/CreateCollectionModal/index.tsx
@@ -25,7 +25,7 @@ const CreateCollection: FC<{ className?: string }> = ({ className }) => {
   const urlParams = new URLSearchParams(window.location.search);
   const param = urlParams.get(QUERY_PARAMETERS.LOGIN_MODULE_REDIRECT);
 
-  const shouldModuleOpen = param?.toLowerCase() === "true";
+  const shouldModuleOpen = param?.toLowerCase() === BOOLEAN.TRUE;
 
   const [isOpen, setIsOpen] = useState(shouldModuleOpen);
   const { data: userInfo, isLoading } = useUserInfo(isAuth);

--- a/frontend/src/components/CreateCollectionModal/index.tsx
+++ b/frontend/src/components/CreateCollectionModal/index.tsx
@@ -25,7 +25,7 @@ const CreateCollection: FC<{ className?: string }> = ({ className }) => {
   const urlParams = new URLSearchParams(window.location.search);
   const param = urlParams.get(QUERY_PARAMETERS.LOGIN_MODULE_REDIRECT);
 
-  const shouldModuleOpen = param !== null && param?.toLowerCase() !== "false";
+  const shouldModuleOpen = param?.toLowerCase() === "true";
 
   const [isOpen, setIsOpen] = useState(shouldModuleOpen);
   const { data: userInfo, isLoading } = useUserInfo(isAuth);

--- a/frontend/src/components/CreateCollectionModal/index.tsx
+++ b/frontend/src/components/CreateCollectionModal/index.tsx
@@ -73,17 +73,16 @@ const CreateCollection: FC<{ className?: string }> = ({ className }) => {
   function toggleOpen() {
     setIsOpen(!isOpen);
     if (shouldModuleOpen) {
-      urlParams.delete(QUERY_PARAMETERS.LOGIN_MODULE_REDIRECT);
-      const currURL = window.location.href;
-      let newURL = currURL.substring(currURL.indexOf("/") + 1).split("?")[0];
-      if (urlParams.toString().length > 0) {
-        newURL = newURL + "?" + urlParams.toString();
-      }
-      console.log(urlParams.toString());
-      console.log(window.location.href);
+      const url = window.location.href;
+      const afterSlashBeforeParam = url
+        .substring(url.indexOf("/") + 1)
+        .split("?")[0];
 
-      window.history.replaceState(null, " ", "/" + newURL);
-      console.log(window.location.href);
+      urlParams.delete(QUERY_PARAMETERS.LOGIN_MODULE_REDIRECT);
+      if (urlParams.toString().length > 0) {
+        const newURL = afterSlashBeforeParam + "?" + urlParams.toString();
+        window.history.replaceState(null, " ", "/" + newURL);
+      }
     }
   }
 };

--- a/frontend/src/components/CreateCollectionModal/index.tsx
+++ b/frontend/src/components/CreateCollectionModal/index.tsx
@@ -1,6 +1,7 @@
 import { Dialog } from "@blueprintjs/core";
 import loadable from "@loadable/component";
 import React, { FC, useState } from "react";
+import { QUERY_PARAMETERS } from "src/common/constants/queryParameters";
 import { get } from "src/common/featureFlags";
 import { FEATURES } from "src/common/featureFlags/features";
 import { BOOLEAN } from "src/common/localStorage/set";
@@ -21,8 +22,12 @@ const AsyncCTA = loadable(
 
 const CreateCollection: FC<{ className?: string }> = ({ className }) => {
   const isAuth = get(FEATURES.AUTH) === BOOLEAN.TRUE;
+  const urlParams = new URLSearchParams(window.location.search);
+  const param = urlParams.get(QUERY_PARAMETERS.LOGIN_MODULE_REDIRECT);
 
-  const [isOpen, setIsOpen] = useState(false);
+  const shouldModuleOpen = param !== null && param?.toLowerCase() !== "false";
+
+  const [isOpen, setIsOpen] = useState(shouldModuleOpen);
   const { data: userInfo, isLoading } = useUserInfo(isAuth);
 
   if (get(FEATURES.CREATE_COLLECTION) !== BOOLEAN.TRUE || isLoading) {
@@ -67,6 +72,19 @@ const CreateCollection: FC<{ className?: string }> = ({ className }) => {
 
   function toggleOpen() {
     setIsOpen(!isOpen);
+    if (shouldModuleOpen) {
+      urlParams.delete(QUERY_PARAMETERS.LOGIN_MODULE_REDIRECT);
+      const currURL = window.location.href;
+      let newURL = currURL.substring(currURL.indexOf("/") + 1).split("?")[0];
+      if (urlParams.toString().length > 0) {
+        newURL = newURL + "?" + urlParams.toString();
+      }
+      console.log(urlParams.toString());
+      console.log(window.location.href);
+
+      window.history.replaceState(null, " ", "/" + newURL);
+      console.log(window.location.href);
+    }
   }
 };
 


### PR DESCRIPTION
Passed query param to auth backend which is sent with redirect.

Front end reads query param and resumes the user's state in the collection creation  flow.

---

QA:

Navigate to `http://localhost:8000/?showCCModule&auth=true&cc=true`

 _also_

On unauthenticated session, authenticating after attempting to create a collection should redirect to:
`https://cellxgene.dev.single-cell.czi.technology/?showCCModule` (redirect is only available on dev as of now)