### PR TITLE
add true value to redirect query param

### DIFF
--- a/frontend/src/components/CreateCollectionModal/components/CTA/index.tsx
+++ b/frontend/src/components/CreateCollectionModal/components/CTA/index.tsx
@@ -28,7 +28,7 @@ const CTA: FC<Props> = ({ onClose }) => {
           </Button>
           <AnchorButton
             intent={Intent.PRIMARY}
-            href={`${API_URL}${API.LOG_IN}?redirect=?${QUERY_PARAMETERS.LOGIN_MODULE_REDIRECT}`}
+            href={`${API_URL}${API.LOG_IN}?redirect=?${QUERY_PARAMETERS.LOGIN_MODULE_REDIRECT}=true`}
           >
             Continue
           </AnchorButton>


### PR DESCRIPTION
Query param wasn't assigned a value to reflect when we changed the param digest to operate only on true values