### PR TITLE
pin rsa>=4.7 in lambda requirements

### DIFF
--- a/backend/chalice/api_server/requirements.txt
+++ b/backend/chalice/api_server/requirements.txt
@@ -5,3 +5,4 @@ psycopg2-binary>=2.8.5
 SQLAlchemy>=1.3.17
 SQLAlchemy-Utils>=0.36.8
 Authlib==0.14.3
+rsa>=4.7 # not directly required, pinned by Snyk to avoid a vulnerability

--- a/backend/chalice/upload_failures/requirements.txt
+++ b/backend/chalice/upload_failures/requirements.txt
@@ -5,3 +5,4 @@ connexion[swagger-ui]==2.7.0
 pyrsistent
 boto3
 chalice==1.12.0
+rsa>=4.7 # not directly required, pinned by Snyk to avoid a vulnerability


### PR DESCRIPTION
#### Reviewers
**Functional:** 

**Readability:** 

---

## Changes
- Pin requirement for  rsa>=4.7 in lambda