### PR TITLE
Make sure name and email are part of ID token

### DIFF
--- a/oauth/clients-config.json
+++ b/oauth/clients-config.json
@@ -15,6 +15,7 @@
            "openid", "profile", "email", "offline_access"
         ],
 	"AllowAccessTokensViaBrowser": true,
+	"AlwaysIncludeUserClaimsInIdToken": true,
 	"AllowOfflineAccess": true,
 	"IdentityTokenLifetime": 3600,
         "AccessTokenLifetime": 3600,


### PR DESCRIPTION
#### Reviewers
**Functional:** 
This change (after a `docker-compose restart oidc` and a logout/login) will make sure the local-dev OIDC service returns email and name as part of the ID token.

**Readability:** 

---

## Changes
- add
- remove
- modify
