### PR TITLE
Fix cancel_pending enum

### DIFF
--- a/backend/config/corpora-api.yml
+++ b/backend/config/corpora-api.yml
@@ -575,7 +575,7 @@ paths:
                         UPLOADING,
                         UPLOADED,
                         FAILED,
-                        CANCEL PENDING,
+                        CANCEL_PENDING,
                         CANCELED,
                         NA,
                       ]


### PR DESCRIPTION
#### Reviewers
**Functional:** @seve 

**Readability:** 

---

## Changes
- modify  GET /dp/v1/datasets/{dataset_uuid}/status to return CANCEL_PENDING rather than CANCEL PENDING
