### PR TITLE
thuang-705-upload-datasets-part-3

### DIFF
--- a/backend/config/corpora-api.yml
+++ b/backend/config/corpora-api.yml
@@ -458,7 +458,7 @@ paths:
         - collection
       summary: Publish a collection
       security:
-        - cxguserCookie: [ ]
+        - cxguserCookie: []
       description: >-
         Update status of specified collection to PUBLIC.  This will make it
         visible on the public sites.
@@ -496,7 +496,7 @@ paths:
         Cancels the download of a dataset to the data portal and cleans up (removes) any artifacts created in the download process
       operationId: corpora.lambdas.api.v1.dataset.delete_dataset
       security:
-        - cxguserCookie: [ ]
+        - cxguserCookie: []
       parameters:
         - $ref: "#/components/parameters/path_dataset_uuid"
       responses:

--- a/frontend/src/common/queries/datasets.ts
+++ b/frontend/src/common/queries/datasets.ts
@@ -36,20 +36,16 @@ export const USE_DELETE_DATASET = {
   id: "dataset",
 };
 
-async function deleteDataset(
-  dataset_uuid?: string
-): Promise<DatasetUploadStatus> {
-  if (!dataset_uuid) throw new Error("No dataset id provided");
-
+async function deleteDataset(dataset_uuid = ""): Promise<DatasetUploadStatus> {
   const url = apiTemplateToUrl(API_URL + API.DATASET, { dataset_uuid });
   const response = await fetch(url, DELETE_FETCH_OPTIONS);
 
   if (response.ok) return await response.json();
 
-  return Promise.reject(response.statusText);
+  throw Error(response.statusText);
 }
 
-export function useDeleteDataset(collection_uuid?: string) {
+export function useDeleteDataset(collection_uuid = "") {
   const queryCache = useQueryCache();
 
   return useMutation(deleteDataset, {

--- a/frontend/src/common/queries/datasets.ts
+++ b/frontend/src/common/queries/datasets.ts
@@ -37,6 +37,8 @@ export const USE_DELETE_DATASET = {
 };
 
 async function deleteDataset(dataset_uuid = ""): Promise<DatasetUploadStatus> {
+  if (!dataset_uuid) throw new Error("No dataset id provided");
+
   const url = apiTemplateToUrl(API_URL + API.DATASET, { dataset_uuid });
   const response = await fetch(url, DELETE_FETCH_OPTIONS);
 
@@ -46,6 +48,10 @@ async function deleteDataset(dataset_uuid = ""): Promise<DatasetUploadStatus> {
 }
 
 export function useDeleteDataset(collection_uuid = "") {
+  if (!collection_uuid) {
+    throw new Error("No collection id given");
+  }
+
   const queryCache = useQueryCache();
 
   return useMutation(deleteDataset, {

--- a/frontend/src/common/queries/datasets.ts
+++ b/frontend/src/common/queries/datasets.ts
@@ -17,6 +17,7 @@ async function fetchDatasetStatus(
   dataset_uuid: string
 ): Promise<DatasetUploadStatus> {
   const url = apiTemplateToUrl(API_URL + API.DATASET_STATUS, { dataset_uuid });
+
   return await (await fetch(url, DEFAULT_FETCH_OPTIONS)).json();
 }
 
@@ -39,16 +40,16 @@ async function deleteDataset(
   dataset_uuid?: string
 ): Promise<DatasetUploadStatus> {
   if (!dataset_uuid) throw new Error("No dataset id provided");
+
   const url = apiTemplateToUrl(API_URL + API.DATASET, { dataset_uuid });
   const response = await fetch(url, DELETE_FETCH_OPTIONS);
+
   if (response.ok) return await response.json();
+
   return Promise.reject(response.statusText);
 }
 
 export function useDeleteDataset(collection_uuid?: string) {
-  if (!collection_uuid) {
-    throw new Error("No collection id given");
-  }
   const queryCache = useQueryCache();
 
   return useMutation(deleteDataset, {
@@ -58,7 +59,9 @@ export function useDeleteDataset(collection_uuid?: string) {
         collection_uuid,
         VISIBILITY_TYPE.PRIVATE,
       ]);
+
       queryCache.cancelQueries([USE_DATASET_STATUS, uploadStatus.dataset_id]);
+
       queryCache.setQueryData(
         [USE_DATASET_STATUS, uploadStatus.dataset_id],
         uploadStatus

--- a/frontend/src/components/Collections/components/Dataset/components/DownloadDataset/components/Content/components/DataFormat/index.tsx
+++ b/frontend/src/components/Collections/components/Dataset/components/DownloadDataset/components/Content/components/DataFormat/index.tsx
@@ -7,12 +7,14 @@ interface Props {
   handleChange: (format: DATASET_ASSET_FORMAT) => void;
   isDisabled: boolean;
   format: DATASET_ASSET_FORMAT | "";
+  availableFormats: DATASET_ASSET_FORMAT[];
 }
 
 const DataFormat: FC<Props> = ({
   handleChange: handleChangeRaw,
   isDisabled = false,
   format,
+  availableFormats,
 }) => {
   const handleChange = (event: React.FormEvent<HTMLElement>) => {
     const value = (event.target as HTMLInputElement)
@@ -31,9 +33,21 @@ const DataFormat: FC<Props> = ({
         onChange={handleChange}
         selectedValue={format}
       >
-        <Radio label=".h5ad (AnnData v0.7)" value={DATASET_ASSET_FORMAT.H5AD} />
-        <Radio label=".loom" value={DATASET_ASSET_FORMAT.LOOM} />
-        <Radio label=".rds (Seurat v3)" value={DATASET_ASSET_FORMAT.RDS} />
+        <Radio
+          disabled={!availableFormats.includes(DATASET_ASSET_FORMAT.H5AD)}
+          label=".h5ad (AnnData v0.7)"
+          value={DATASET_ASSET_FORMAT.H5AD}
+        />
+        <Radio
+          disabled={!availableFormats.includes(DATASET_ASSET_FORMAT.LOOM)}
+          label=".loom"
+          value={DATASET_ASSET_FORMAT.LOOM}
+        />
+        <Radio
+          disabled={!availableFormats.includes(DATASET_ASSET_FORMAT.RDS)}
+          label=".rds (Seurat v3)"
+          value={DATASET_ASSET_FORMAT.RDS}
+        />
       </RadioGroup>
     </Section>
   );

--- a/frontend/src/components/Collections/components/Dataset/components/DownloadDataset/components/Content/index.tsx
+++ b/frontend/src/components/Collections/components/Dataset/components/DownloadDataset/components/Content/index.tsx
@@ -1,4 +1,4 @@
-import { Classes } from "@blueprintjs/core";
+import { Classes, Intent } from "@blueprintjs/core";
 import React, { FC, useEffect, useState } from "react";
 import { API } from "src/common/API";
 import { Dataset, DATASET_ASSET_FORMAT } from "src/common/entities";
@@ -8,7 +8,7 @@ import CurlLink from "./components/CurlLink";
 import DataFormat from "./components/DataFormat";
 import Details from "./components/Details";
 import Name from "./components/Name";
-import { Cancel, DisabledDownload, Download, Wrapper } from "./style";
+import { CancelButton, DownloadButton, Wrapper } from "./style";
 
 interface Props {
   onClose: () => void;
@@ -20,7 +20,7 @@ const Content: FC<Props> = ({ onClose, name, dataAssets }) => {
   const [format, setFormat] = useState<DATASET_ASSET_FORMAT | "">("");
   const [fileSize, setFileSize] = useState<number>(0);
   const [fileName, setFileName] = useState<string>("");
-  const [downloadLink, setDownloadLink] = useState<string | null>(null);
+  const [downloadLink, setDownloadLink] = useState<string>("");
   const [isLoading, setIsLoading] = useState<boolean>(false);
 
   useEffect(() => {
@@ -50,17 +50,15 @@ const Content: FC<Props> = ({ onClose, name, dataAssets }) => {
   };
 
   const renderDownload = () => {
-    if (!downloadLink || isLoading) {
-      return <DisabledDownload>Download</DisabledDownload>;
-    }
-
     return (
-      <Download
+      <DownloadButton
+        disabled={!downloadLink || isLoading}
         data-test-id="download-asset-download-button"
         href={downloadLink}
+        intent={Intent.PRIMARY}
       >
         Download
-      </Download>
+      </DownloadButton>
     );
   };
 
@@ -88,7 +86,9 @@ const Content: FC<Props> = ({ onClose, name, dataAssets }) => {
         </Wrapper>
       </div>
       <div className={Classes.DIALOG_FOOTER}>
-        <Cancel onClick={onClose}>Cancel</Cancel>
+        <CancelButton onClick={onClose} minimal>
+          Cancel
+        </CancelButton>
         {renderDownload()}
       </div>
     </>

--- a/frontend/src/components/Collections/components/Dataset/components/DownloadDataset/components/Content/index.tsx
+++ b/frontend/src/components/Collections/components/Dataset/components/DownloadDataset/components/Content/index.tsx
@@ -64,6 +64,8 @@ const Content: FC<Props> = ({ onClose, name, dataAssets }) => {
     );
   };
 
+  const availableFormats = dataAssets.map((dataAsset) => dataAsset.filetype);
+
   return (
     <>
       <div className={Classes.DIALOG_BODY}>
@@ -73,6 +75,7 @@ const Content: FC<Props> = ({ onClose, name, dataAssets }) => {
             handleChange={handleChange}
             isDisabled={isLoading}
             format={format}
+            availableFormats={availableFormats}
           />
           <Details
             isLoading={isLoading}

--- a/frontend/src/components/Collections/components/Dataset/components/DownloadDataset/components/Content/style.ts
+++ b/frontend/src/components/Collections/components/Dataset/components/DownloadDataset/components/Content/style.ts
@@ -1,54 +1,16 @@
-import { OLD_BLUE, OLD_GRAY } from "src/components/common/theme";
-import styled, { css } from "styled-components";
+import { AnchorButton, Button } from "@blueprintjs/core";
+import { PT_GRID_SIZE_PX } from "src/components/common/theme";
+import styled from "styled-components";
 
 export const Wrapper = styled.div`
   width: 625px;
   height: 300px;
 `;
 
-const buttonStyle = css`
-  margin-right: 10px;
-  border: none;
-  cursor: pointer;
+export const DownloadButton = styled(AnchorButton)`
+  margin-right: ${PT_GRID_SIZE_PX}px;
 `;
 
-export const Cancel = styled.button`
-  ${buttonStyle}
-  background-color: transparent;
-  color: ${OLD_GRAY.DARK};
-  font-size: 14px;
-`;
-
-const sharedDownloadStyle = css`
-  ${buttonStyle}
-  background-color: ${OLD_BLUE};
-  color: white;
-  font-size: 14px;
-  width: 80px;
-  height: 37px;
-  border-radius: 4px;
-  margin-right: 10px;
-`;
-
-export const DisabledDownload = styled.button`
-  ${sharedDownloadStyle}
-
-  cursor: default;
-  opacity: 0.6;
-  filter: unset;
-`;
-
-export const Download = styled.a`
-  ${sharedDownloadStyle}
-
-  display: flex;
-  align-items: center;
-  justify-content: center;
-
-  :hover {
-    filter: brightness(1.1);
-    color: white;
-    cursor: pointer;
-    text-decoration: none;
-  }
+export const CancelButton = styled(Button)`
+  margin-right: ${PT_GRID_SIZE_PX}px;
 `;

--- a/frontend/src/components/Collections/components/Dataset/components/DownloadDataset/index.tsx
+++ b/frontend/src/components/Collections/components/Dataset/components/DownloadDataset/index.tsx
@@ -8,18 +8,29 @@ import { StyledButton } from "./style";
 interface Props {
   name: string;
   dataAssets: Dataset["dataset_assets"];
+  isDisabled?: boolean;
+  Button?: React.ElementType;
 }
 
-const DownloadDataset: FC<Props> = ({ name, dataAssets }) => {
+const DownloadDataset: FC<Props> = ({
+  name,
+  dataAssets,
+  isDisabled = false,
+  Button = StyledButton,
+}) => {
   const [isOpen, setIsOpen] = React.useState(false);
 
   const toggleOpen = () => setIsOpen(!isOpen);
 
   return (
     <SmallColumn>
-      <StyledButton onClick={toggleOpen} data-test-id="dataset-download-button">
+      <Button
+        disabled={isDisabled}
+        onClick={toggleOpen}
+        data-test-id="dataset-download-button"
+      >
         Download
-      </StyledButton>
+      </Button>
       <Modal title="Download Dataset" isOpen={isOpen} onClose={toggleOpen}>
         <Content name={name} dataAssets={dataAssets} onClose={toggleOpen} />
       </Modal>

--- a/frontend/src/components/Collections/components/Grid/components/DatasetsGrid/index.tsx
+++ b/frontend/src/components/Collections/components/Grid/components/DatasetsGrid/index.tsx
@@ -18,7 +18,7 @@ interface Props {
   datasets: Dataset[];
   uploadedFiles: UploadedFiles;
   invalidateCollectionQuery: () => void;
-  onSelect: Dispatch<SetStateAction<string | undefined>>;
+  onSelect: Dispatch<SetStateAction<string>>;
 }
 
 const DatasetsGrid: FC<Props> = ({
@@ -27,7 +27,7 @@ const DatasetsGrid: FC<Props> = ({
   invalidateCollectionQuery,
   onSelect,
 }) => {
-  const [selected, setSelected] = useState<Dataset["id"]>();
+  const [selected, setSelected] = useState<Dataset["id"]>("");
 
   useEffect(() => {
     onSelect(selected);

--- a/frontend/src/components/Collections/components/Grid/components/Row/DatasetRow/components/DeleteDataset/index.tsx
+++ b/frontend/src/components/Collections/components/Grid/components/Row/DatasetRow/components/DeleteDataset/index.tsx
@@ -1,0 +1,51 @@
+import { Button as RawButton, H6, Intent } from "@blueprintjs/core";
+import { IconNames } from "@blueprintjs/icons";
+import React, { FC, useState } from "react";
+import { useDeleteDataset } from "src/common/queries/datasets";
+import { StyledAlert } from "./style";
+
+interface Props {
+  id?: string;
+  collectionId?: string;
+  Button?: React.ElementType;
+}
+
+const DeleteDataset: FC<Props> = ({
+  id,
+  collectionId,
+  Button = DefaultButton,
+}) => {
+  const [isOpen, setIsOpen] = useState(false);
+
+  const [deleteDataset] = useDeleteDataset(collectionId);
+
+  const toggleAlert = () => {
+    setIsOpen(!isOpen);
+  };
+
+  return (
+    <>
+      <Button disabled={!id} onClick={toggleAlert} />
+      <StyledAlert
+        cancelButtonText={"Cancel"}
+        confirmButtonText={"Delete Dataset"}
+        intent={Intent.DANGER}
+        isOpen={isOpen}
+        onCancel={toggleAlert}
+        onConfirm={() => {
+          deleteDataset(id);
+          toggleAlert();
+        }}
+      >
+        <H6>Are you sure you want to delete this dataset?</H6>
+        <p>You cannot undo this action</p>
+      </StyledAlert>
+    </>
+  );
+};
+
+function DefaultButton({ ...props }) {
+  return <RawButton icon={IconNames.TRASH} minimal {...props} />;
+}
+
+export default DeleteDataset;

--- a/frontend/src/components/Collections/components/Grid/components/Row/DatasetRow/components/DeleteDataset/style.ts
+++ b/frontend/src/components/Collections/components/Grid/components/Row/DatasetRow/components/DeleteDataset/style.ts
@@ -1,0 +1,15 @@
+import { Alert, Classes } from "@blueprintjs/core";
+import { BLUE, RED } from "src/components/common/theme";
+import styled from "styled-components";
+
+export const StyledAlert = styled(Alert)`
+  .${Classes.BUTTON} {
+    background: ${RED.C};
+    box-shadow: none !important;
+
+    :not(.${Classes.INTENT_DANGER}) {
+      color: ${BLUE.C};
+      background: none;
+    }
+  }
+`;

--- a/frontend/src/components/Collections/components/Grid/components/Row/DatasetRow/components/DeleteDataset/style.ts
+++ b/frontend/src/components/Collections/components/Grid/components/Row/DatasetRow/components/DeleteDataset/style.ts
@@ -1,15 +1,17 @@
 import { Alert, Classes } from "@blueprintjs/core";
-import { BLUE, RED } from "src/components/common/theme";
+import { DARK_GRAY } from "src/components/common/theme";
 import styled from "styled-components";
 
 export const StyledAlert = styled(Alert)`
   .${Classes.BUTTON} {
-    background: ${RED.C};
-    box-shadow: none !important;
-
     :not(.${Classes.INTENT_DANGER}) {
-      color: ${BLUE.C};
       background: none;
+      box-shadow: none !important;
+      color: ${DARK_GRAY.A};
+
+      &:hover {
+        background: rgba(167, 182, 194, 0.3);
+      }
     }
   }
 `;

--- a/frontend/src/components/Collections/components/Grid/components/Row/DatasetRow/components/Popover/index.tsx
+++ b/frontend/src/components/Collections/components/Grid/components/Row/DatasetRow/components/Popover/index.tsx
@@ -13,10 +13,9 @@ const AsyncPopover = loadable(
 interface Props {
   values: string[];
   isLoading: boolean;
-  isFailed: boolean;
 }
 
-const Popover: FC<Props> = ({ values, isLoading, isFailed }) => {
+const Popover: FC<Props> = ({ values, isLoading }) => {
   if (isLoading) {
     return (
       <td>
@@ -25,7 +24,7 @@ const Popover: FC<Props> = ({ values, isLoading, isFailed }) => {
     );
   }
 
-  if (isFailed || !values || values.length === 0) {
+  if (!values || values.length === 0) {
     return <LeftAlignedDetailsCell>-</LeftAlignedDetailsCell>;
   }
 

--- a/frontend/src/components/Collections/components/Grid/components/Row/DatasetRow/components/Tooltip/index.tsx
+++ b/frontend/src/components/Collections/components/Grid/components/Row/DatasetRow/components/Tooltip/index.tsx
@@ -6,44 +6,84 @@ import {
 } from "@blueprintjs/core";
 import { IconNames } from "@blueprintjs/icons";
 import React, { FC } from "react";
-import { UPLOAD_STATUS, VALIDATION_STATUS } from "src/common/entities";
-import { RED } from "src/components/common/theme";
+import {
+  CONVERSION_STATUS,
+  UPLOAD_STATUS,
+  VALIDATION_STATUS,
+} from "src/common/entities";
+import { ORANGE, RED } from "src/components/common/theme";
+import { FAILED_RETURN_TYPE, FailReturn } from "../../utils";
 import { StyledAnchor } from "./style";
 
-const tooltipContent = (error: VALIDATION_STATUS | UPLOAD_STATUS) => {
-  return error === VALIDATION_STATUS.INVALID ? (
-    <span>
-      You must validate your dataset locally before uploading. We provide a
-      local CLI script to do this.{" "}
-      <b>
-        <StyledAnchor
-          href="https://github.com/chanzuckerberg/cellxgene/blob/main/dev_docs/schema_guide.md"
-          target="_blank"
-        >
-          Learn More
-        </StyledAnchor>
-      </b>
-    </span>
-  ) : (
-    <span>There was a problem uploading your file. Please try again.</span>
-  );
+interface Content {
+  color: string;
+  intent: Intent;
+  content: JSX.Element;
+}
+
+const ERROR_TO_CONTENT: { [key: string]: Content } = {
+  [FAILED_RETURN_TYPE.VALIDATION + VALIDATION_STATUS.INVALID]: {
+    color: RED.C,
+    content: (
+      <span>
+        You must validate your dataset locally before uploading. We provide a
+        local CLI script to do this.{" "}
+        <b>
+          <StyledAnchor
+            href="https://github.com/chanzuckerberg/cellxgene/blob/main/dev_docs/schema_guide.md"
+            target="_blank"
+          >
+            Learn More
+          </StyledAnchor>
+        </b>
+      </span>
+    ),
+    intent: Intent.DANGER,
+  },
+  [FAILED_RETURN_TYPE.CONVERSION + CONVERSION_STATUS.FAILED]: {
+    color: ORANGE.C,
+    content: (
+      <span>
+        The dataset was uploaded successfully, but one or more conversions from
+        .h5ad failed. We&apos;ll attempt to fix this manually and follow-up in
+        an email after we&apos;ve investigated.
+      </span>
+    ),
+    intent: Intent.WARNING,
+  },
+  [FAILED_RETURN_TYPE.UPLOAD + UPLOAD_STATUS.FAILED]: {
+    color: RED.C,
+    content: (
+      <span>There was a problem uploading your file. Please try again.</span>
+    ),
+    intent: Intent.DANGER,
+  },
+};
+
+const DEFAULT_CONTENT: Content = {
+  color: RED.C,
+  content: <span>There was an unexpected problem. Please try again.</span>,
+  intent: Intent.DANGER,
 };
 
 interface Props {
-  error?: VALIDATION_STATUS | UPLOAD_STATUS;
+  error?: VALIDATION_STATUS | UPLOAD_STATUS | CONVERSION_STATUS;
+  type?: FailReturn["type"];
 }
 
-const Tooltip: FC<Props> = ({ error }) => {
+const Tooltip: FC<Props> = ({ error, type }) => {
   if (!error) return null;
+
+  const content = ERROR_TO_CONTENT[type + error] || DEFAULT_CONTENT;
 
   return (
     <TooltipRaw
-      intent={Intent.DANGER}
+      intent={content.intent}
       interactionKind={PopoverInteractionKind.HOVER}
       hoverCloseDelay={500}
-      content={tooltipContent(error)}
+      content={content.content}
     >
-      <Icon icon={IconNames.ISSUE} iconSize={16} color={RED.C} />
+      <Icon icon={IconNames.ISSUE} iconSize={16} color={content.color} />
     </TooltipRaw>
   );
 };

--- a/frontend/src/components/Collections/components/Grid/components/Row/DatasetRow/components/UploadStatus/index.tsx
+++ b/frontend/src/components/Collections/components/Grid/components/Row/DatasetRow/components/UploadStatus/index.tsx
@@ -1,37 +1,65 @@
-import { Intent, Spinner } from "@blueprintjs/core";
+import { Button, Intent } from "@blueprintjs/core";
 import React, { FC } from "react";
-import { CancelButton, DatasetStatusTag, StatusContainer } from "./style";
+import DeleteDataset from "../DeleteDataset";
+import { DatasetStatusTag, StatusContainer, StyledSpinner } from "./style";
 
 interface Props {
+  isConverting: boolean;
   isValidating: boolean;
   progress: number;
-  cancelUpload: () => void;
+  datasetId: string;
+  collectionId: string;
 }
 
-const UploadStatus: FC<Props> = ({ isValidating, progress, cancelUpload }) => {
-  const cancel = <CancelButton onClick={cancelUpload}>Cancel</CancelButton>;
+const UploadStatus: FC<Props> = ({
+  isConverting,
+  isValidating,
+  progress,
+  datasetId,
+  collectionId,
+}) => {
+  let content: { progress?: number; text: string } = {
+    progress,
+    text: `Uploading (${Math.round(progress * 100)}%)`,
+  };
+
+  if (isConverting) {
+    content = {
+      text: "Processing...",
+    };
+  }
 
   if (isValidating) {
-    return (
-      <StatusContainer>
-        <DatasetStatusTag>
-          <Spinner intent={Intent.PRIMARY} size={16} />
-          Validating...
-        </DatasetStatusTag>
-        {cancel}
-      </StatusContainer>
-    );
+    content = {
+      text: "Validating...",
+    };
   }
 
   return (
     <StatusContainer>
       <DatasetStatusTag>
-        <Spinner intent={Intent.PRIMARY} value={progress} size={16} />
-        {`Uploading (${Math.round(progress * 100)}%)`}
+        <StyledSpinner
+          intent={Intent.PRIMARY}
+          value={content.progress}
+          size={16}
+        />
+        {content.text}
       </DatasetStatusTag>
-      {cancel}
+      <DeleteDataset
+        id={datasetId}
+        collectionId={collectionId}
+        Button={CancelButton}
+      />
     </StatusContainer>
   );
 };
+
+function CancelButton({ ...props }) {
+  return (
+    <Button minimal {...props}>
+      Cancel
+    </Button>
+  );
+}
 
 export default UploadStatus;

--- a/frontend/src/components/Collections/components/Grid/components/Row/DatasetRow/components/UploadStatus/style.ts
+++ b/frontend/src/components/Collections/components/Grid/components/Row/DatasetRow/components/UploadStatus/style.ts
@@ -1,4 +1,4 @@
-import { Classes, Intent } from "@blueprintjs/core";
+import { Intent, Spinner } from "@blueprintjs/core";
 import {
   GRAY,
   LIGHT_GRAY,
@@ -20,7 +20,8 @@ const intentColorSwitch = (intent: Intent, border?: boolean) => {
 export const StatusContainer = styled.div`
   display: flex;
   flex-direction: row;
-  vertical-align: middle;
+  align-items: center;
+  margin-bottom: ${PT_GRID_SIZE_PX}px;
 `;
 
 interface Props {
@@ -35,23 +36,12 @@ export const DatasetStatusTag = styled.div`
   align-self: flex-start;
   width: fit-content;
   padding: ${PT_GRID_SIZE_PX}px;
-  margin: 0 auto;
   display: flex;
   flex-direction: row;
   vertical-align: middle;
-  & > .${Classes.SPINNER}, .${Classes.ICON} {
-    margin: auto ${PT_GRID_SIZE_PX}px auto 0;
-    height: 100%;
-  }
+  margin-right: ${PT_GRID_SIZE_PX}px;
 `;
 
-export const CancelButton = styled.button`
-  :hover {
-    color: ${RED.C};
-  }
-
-  outline: none;
-  border: 0;
-  color: ${GRAY.A};
-  background: none;
+export const StyledSpinner = styled(Spinner)`
+  margin-right: ${PT_GRID_SIZE_PX}px;
 `;

--- a/frontend/src/components/Collections/components/Grid/components/Row/DatasetRow/index.tsx
+++ b/frontend/src/components/Collections/components/Grid/components/Row/DatasetRow/index.tsx
@@ -99,7 +99,7 @@ const DatasetRow: FC<Props> = ({
   useCheckCollectionPopulated({
     invalidateCollectionQuery,
     isNamePopulated,
-    upload_progress,
+    validationStatus: datasetStatus.validation_status,
   });
 
   const hasFailed = checkIfFailed(datasetStatus);

--- a/frontend/src/components/Collections/components/Grid/components/Row/DatasetRow/index.tsx
+++ b/frontend/src/components/Collections/components/Grid/components/Row/DatasetRow/index.tsx
@@ -1,14 +1,13 @@
-import { Button, Intent, Radio } from "@blueprintjs/core";
-import { IconNames } from "@blueprintjs/icons";
+import { AnchorButton, Intent, Radio } from "@blueprintjs/core";
 import loadable from "@loadable/component";
-import React, { FC, useEffect, useState } from "react";
-import { CancelledError, QueryCache, useQueryCache } from "react-query";
-import { Dataset, VALIDATION_STATUS } from "src/common/entities";
+import React, { FC } from "react";
+import { CancelledError, useQueryCache } from "react-query";
 import {
-  useDatasetStatus,
-  useDeleteDataset,
-  USE_DATASET_STATUS,
-} from "src/common/queries/datasets";
+  CONVERSION_STATUS,
+  Dataset,
+  VALIDATION_STATUS,
+} from "src/common/entities";
+import { useDatasetStatus } from "src/common/queries/datasets";
 import { aggregateDatasetsMetadata } from "src/components/Collections/components/Grid/common/utils";
 import {
   DetailsCell,
@@ -16,7 +15,6 @@ import {
   StyledRow,
 } from "src/components/Collections/components/Grid/components/Row/common/style.ts";
 import { UploadingFile } from "src/components/DropboxChooser";
-import DatasetUploadToast from "src/views/Collection/components/DatasetUploadToast";
 import CellCount from "./components/CellCount";
 import Popover from "./components/Popover";
 import UploadStatus from "./components/UploadStatus";
@@ -25,10 +23,16 @@ import {
   checkIfCancelled,
   checkIfFailed,
   checkIfLoading,
+  checkIfMetadataLoading,
   FailReturn,
+  getConversionStatus,
+  hasCXGFile,
+  useCancelDatasetStatusQuery,
+  useCheckCollectionFormatsPopulated,
+  useCheckCollectionPopulated,
+  useConversionProgress,
+  useUploadProgress,
 } from "./utils";
-
-const FETCH_COLLECTION_INTERVAL_MS = 5 * 1000;
 
 const AsyncTooltip = loadable(
   () =>
@@ -37,10 +41,10 @@ const AsyncTooltip = loadable(
     )
 );
 
-const ErrorTooltip = ({ isFailed, error }: FailReturn) => {
+const ErrorTooltip = ({ isFailed, error, type }: FailReturn) => {
   if (!isFailed) return null;
 
-  return <AsyncTooltip error={error} />;
+  return <AsyncTooltip error={error} type={type} />;
 };
 
 interface Props {
@@ -48,7 +52,7 @@ interface Props {
   file?: UploadingFile;
   invalidateCollectionQuery: () => void;
   onSelect: (id: Dataset["id"]) => void;
-  selected: Dataset["id"] | undefined;
+  selected?: Dataset["id"];
 }
 
 const DatasetRow: FC<Props> = ({
@@ -60,23 +64,35 @@ const DatasetRow: FC<Props> = ({
 }) => {
   const queryCache = useQueryCache();
 
-  const queryResult = useDatasetStatus(
+  const datasetStatusResult = useDatasetStatus(
     dataset.id,
     checkIfLoading(dataset.processing_status)
   );
 
-  const datasetStatus = queryResult.data || dataset.processing_status;
+  const datasetStatus = datasetStatusResult.data || dataset.processing_status;
+
+  const initProgress = dataset?.processing_status?.upload_progress;
 
   const { upload_progress } = datasetStatus;
 
-  const [uploadProgress, setUploadProgress] = useState(upload_progress);
-
-  if (queryResult.isError && !(queryResult.error instanceof CancelledError)) {
-    console.error(queryResult.error);
+  if (
+    datasetStatusResult.isError &&
+    !(datasetStatusResult.error instanceof CancelledError)
+  ) {
+    console.error(datasetStatusResult.error);
   }
+
   const isNamePopulated = Boolean(dataset.name);
 
   const name = dataset.name || file?.name || dataset.id;
+
+  // (thuang): We need to poll the collection until all the converted files
+  // become available
+  useCheckCollectionFormatsPopulated({
+    dataset,
+    datasetUploadStatus: datasetStatus,
+    invalidateCollectionQuery,
+  });
 
   // (thuang): We need to poll the collection until the name is populated,
   // which indicates other metadata are populated too
@@ -87,26 +103,30 @@ const DatasetRow: FC<Props> = ({
   });
 
   const hasFailed = checkIfFailed(datasetStatus);
-  const { isFailed, error } = hasFailed;
+  const { isFailed, error, type } = hasFailed;
+
+  const isLoading = checkIfLoading(datasetStatus);
+
+  const isMetadataLoading = checkIfMetadataLoading(dataset, datasetStatus);
 
   useCancelDatasetStatusQuery({
     datasetId: dataset.id,
     isFailed,
-    isNamePopulated,
+    isLoading,
     queryCache,
   });
 
   useUploadProgress({
-    newUploadProgress: upload_progress,
-    setUploadProgress,
-    uploadProgress,
+    initProgress: initProgress,
+    progress: upload_progress,
   });
 
-  const [deleteDataset] = useDeleteDataset(dataset.collection_id);
+  useConversionProgress({
+    datasetStatus: datasetStatusResult.data,
+    initDatasetStatus: dataset.processing_status,
+  });
 
   if (checkIfCancelled(datasetStatus)) return null;
-
-  const isLoading = checkIfLoading(datasetStatus);
 
   const {
     tissue,
@@ -125,99 +145,45 @@ const DatasetRow: FC<Props> = ({
             checked={selected === dataset.id}
           />
           <div>{name}</div>
-          <ErrorTooltip isFailed={isFailed} error={error} />
+          {!isLoading && (
+            <ErrorTooltip isFailed={isFailed} error={error} type={type} />
+          )}
         </TitleContainer>
         {isLoading && (
           <UploadStatus
+            isConverting={
+              getConversionStatus(datasetStatus) ===
+              CONVERSION_STATUS.CONVERTING
+            }
             isValidating={
               datasetStatus.validation_status === VALIDATION_STATUS.VALIDATING
             }
             progress={datasetStatus.upload_progress}
-            cancelUpload={() => {
-              deleteDataset(dataset.id);
-            }}
+            datasetId={dataset.id}
+            collectionId={dataset.collection_id}
           />
         )}
       </DetailsCell>
-      <Popover values={tissue} isLoading={isLoading} isFailed={isFailed} />
-      <Popover values={assay} isLoading={isLoading} isFailed={isFailed} />
-      <Popover values={disease} isLoading={isLoading} isFailed={isFailed} />
-      <Popover values={organism} isLoading={isLoading} isFailed={isFailed} />
-      <CellCount cellCount={cell_count} isLoading={isLoading} />
+      <Popover values={tissue} isLoading={isMetadataLoading} />
+      <Popover values={assay} isLoading={isMetadataLoading} />
+      <Popover values={disease} isLoading={isMetadataLoading} />
+      <Popover values={organism} isLoading={isMetadataLoading} />
+      <CellCount cellCount={cell_count} isLoading={isMetadataLoading} />
       <RightAlignedDetailsCell>
-        {isNamePopulated && (
-          <Button intent={Intent.PRIMARY} outlined text="Explore" />
+        {hasCXGFile(dataset) && (
+          <AnchorButton
+            intent={Intent.PRIMARY}
+            outlined
+            text="Explore"
+            href={dataset?.dataset_deployments[0]?.url}
+            target="_blank"
+            rel="noopener"
+            data-test-id="view-dataset-link"
+          />
         )}
       </RightAlignedDetailsCell>
     </StyledRow>
   );
 };
-
-function useCheckCollectionPopulated({
-  invalidateCollectionQuery,
-  isNamePopulated,
-  upload_progress,
-}: {
-  invalidateCollectionQuery: () => void;
-  isNamePopulated: boolean;
-  upload_progress: number;
-}) {
-  useEffect(() => {
-    let intervalId: number | undefined = undefined;
-
-    if (!intervalId && upload_progress === 1 && !isNamePopulated) {
-      intervalId = window?.setInterval(() => {
-        if (upload_progress === 1 && !isNamePopulated) {
-          invalidateCollectionQuery();
-        }
-      }, FETCH_COLLECTION_INTERVAL_MS);
-    }
-
-    return () => clearInterval(intervalId);
-  }, [invalidateCollectionQuery, isNamePopulated, upload_progress]);
-}
-
-function useCancelDatasetStatusQuery({
-  datasetId,
-  isFailed,
-  isNamePopulated,
-  queryCache,
-}: {
-  datasetId: string;
-  isFailed: boolean;
-  isNamePopulated: boolean;
-  queryCache: QueryCache;
-}) {
-  useEffect(() => {
-    if (isFailed || isNamePopulated) {
-      queryCache.cancelQueries([USE_DATASET_STATUS, datasetId]);
-    }
-  }, [datasetId, isFailed, isNamePopulated, queryCache]);
-}
-
-function useUploadProgress({
-  newUploadProgress,
-  setUploadProgress,
-  uploadProgress,
-}: {
-  newUploadProgress: number;
-  setUploadProgress: React.Dispatch<React.SetStateAction<number>>;
-  uploadProgress: number;
-}) {
-  useEffect(() => {
-    if (uploadProgress === newUploadProgress) return;
-
-    setUploadProgress(newUploadProgress);
-
-    if (newUploadProgress === 1) {
-      DatasetUploadToast.show({
-        icon: IconNames.TICK,
-        intent: Intent.SUCCESS,
-        message:
-          "Upload was successful. Your file is being processed which will continue in the background, even if you close this window.",
-      });
-    }
-  }, [newUploadProgress, setUploadProgress, uploadProgress]);
-}
 
 export default DatasetRow;

--- a/frontend/src/components/Collections/components/Grid/components/Row/DatasetRow/utils.ts
+++ b/frontend/src/components/Collections/components/Grid/components/Row/DatasetRow/utils.ts
@@ -25,6 +25,14 @@ export type FailReturn = {
 };
 
 export function checkIfFailed(datasetStatus: DatasetUploadStatus): FailReturn {
+  if (getConversionStatus(datasetStatus) === CONVERSION_STATUS.FAILED) {
+    return {
+      error: CONVERSION_STATUS.FAILED,
+      isFailed: true,
+      type: FAILED_RETURN_TYPE.CONVERSION,
+    };
+  }
+
   if (datasetStatus.validation_status === VALIDATION_STATUS.INVALID) {
     return {
       error: VALIDATION_STATUS.INVALID,
@@ -38,14 +46,6 @@ export function checkIfFailed(datasetStatus: DatasetUploadStatus): FailReturn {
       error: UPLOAD_STATUS.FAILED,
       isFailed: true,
       type: FAILED_RETURN_TYPE.UPLOAD,
-    };
-  }
-
-  if (getConversionStatus(datasetStatus) === CONVERSION_STATUS.FAILED) {
-    return {
-      error: CONVERSION_STATUS.FAILED,
-      isFailed: true,
-      type: FAILED_RETURN_TYPE.CONVERSION,
     };
   }
 

--- a/frontend/src/components/Collections/components/Grid/components/Row/DatasetRow/utils.ts
+++ b/frontend/src/components/Collections/components/Grid/components/Row/DatasetRow/utils.ts
@@ -93,15 +93,16 @@ export function checkIfCancelled(datasetStatus: DatasetUploadStatus): boolean {
 export function useCheckCollectionPopulated({
   invalidateCollectionQuery,
   isNamePopulated,
-  upload_progress,
+  validationStatus,
 }: {
   invalidateCollectionQuery: () => void;
   isNamePopulated: boolean;
-  upload_progress: number;
+  validationStatus: VALIDATION_STATUS;
 }) {
   useCheckCollection({
     invalidateCollectionQuery,
-    shouldFetch: upload_progress === 1 && !isNamePopulated,
+    shouldFetch:
+      validationStatus === VALIDATION_STATUS.VALID && !isNamePopulated,
   });
 }
 

--- a/frontend/src/components/Collections/components/Grid/components/Row/DatasetRow/utils.ts
+++ b/frontend/src/components/Collections/components/Grid/components/Row/DatasetRow/utils.ts
@@ -1,26 +1,65 @@
+import { Intent } from "@blueprintjs/core";
+import { IconNames } from "@blueprintjs/icons";
+import { useEffect } from "react";
+import { QueryCache } from "react-query";
 import {
   CONVERSION_STATUS,
+  Dataset,
   DatasetUploadStatus,
   UPLOAD_STATUS,
   VALIDATION_STATUS,
 } from "src/common/entities";
+import { USE_DATASET_STATUS } from "src/common/queries/datasets";
+import DatasetUploadToast from "src/views/Collection/components/DatasetUploadToast";
+
+export enum FAILED_RETURN_TYPE {
+  UPLOAD = "UPLOAD",
+  VALIDATION = "VALIDATION",
+  CONVERSION = "CONVERSIOn",
+}
 
 export type FailReturn = {
   isFailed: boolean;
-  error?: VALIDATION_STATUS | UPLOAD_STATUS;
+  error?: VALIDATION_STATUS | UPLOAD_STATUS | CONVERSION_STATUS;
+  type?: FAILED_RETURN_TYPE;
 };
 
 export function checkIfFailed(datasetStatus: DatasetUploadStatus): FailReturn {
   if (datasetStatus.validation_status === VALIDATION_STATUS.INVALID) {
-    return { error: VALIDATION_STATUS.INVALID, isFailed: true };
+    return {
+      error: VALIDATION_STATUS.INVALID,
+      isFailed: true,
+      type: FAILED_RETURN_TYPE.VALIDATION,
+    };
   }
 
   if (datasetStatus.upload_status === UPLOAD_STATUS.FAILED) {
-    return { error: UPLOAD_STATUS.FAILED, isFailed: true };
+    return {
+      error: UPLOAD_STATUS.FAILED,
+      isFailed: true,
+      type: FAILED_RETURN_TYPE.UPLOAD,
+    };
   }
 
-  // TODO: check if conversion failed
+  if (getConversionStatus(datasetStatus) === CONVERSION_STATUS.FAILED) {
+    return {
+      error: CONVERSION_STATUS.FAILED,
+      isFailed: true,
+      type: FAILED_RETURN_TYPE.CONVERSION,
+    };
+  }
+
   return { isFailed: false };
+}
+
+export function checkIfMetadataLoading(
+  dataset: Dataset,
+  datasetStatus: DatasetUploadStatus
+) {
+  const isFailed = checkIfFailed(datasetStatus).isFailed;
+  const isNamePopulated = Boolean(dataset.name);
+
+  return !isFailed && !isNamePopulated;
 }
 
 export const checkIfLoading = (datasetStatus: DatasetUploadStatus): boolean => {
@@ -37,12 +76,7 @@ export const checkIfLoading = (datasetStatus: DatasetUploadStatus): boolean => {
     return true;
   }
 
-  if (
-    datasetStatus.conversion_anndata_status === CONVERSION_STATUS.CONVERTING ||
-    datasetStatus.conversion_cxg_status === CONVERSION_STATUS.CONVERTING ||
-    datasetStatus.conversion_rds_status === CONVERSION_STATUS.CONVERTING ||
-    datasetStatus.conversion_loom_status === CONVERSION_STATUS.CONVERTING
-  ) {
+  if (getConversionStatus(datasetStatus) === CONVERSION_STATUS.CONVERTING) {
     return true;
   }
 
@@ -54,4 +88,219 @@ export function checkIfCancelled(datasetStatus: DatasetUploadStatus): boolean {
     datasetStatus.upload_status === UPLOAD_STATUS.CANCEL_PENDING ||
     datasetStatus.upload_status === UPLOAD_STATUS.CANCELED
   );
+}
+
+export function useCheckCollectionPopulated({
+  invalidateCollectionQuery,
+  isNamePopulated,
+  upload_progress,
+}: {
+  invalidateCollectionQuery: () => void;
+  isNamePopulated: boolean;
+  upload_progress: number;
+}) {
+  useCheckCollection({
+    invalidateCollectionQuery,
+    shouldFetch: upload_progress === 1 && !isNamePopulated,
+  });
+}
+
+type FORMAT_KEYS =
+  | "conversion_loom_status"
+  | "conversion_anndata_status"
+  | "conversion_cxg_status"
+  | "conversion_rds_status";
+
+const CONVERSION_STATUS_FORMAT_KEYS = [
+  "conversion_loom_status",
+  "conversion_anndata_status",
+  "conversion_cxg_status",
+  "conversion_rds_status",
+] as FORMAT_KEYS[];
+
+export function useCheckCollectionFormatsPopulated({
+  invalidateCollectionQuery,
+  dataset,
+  datasetUploadStatus,
+}: {
+  invalidateCollectionQuery: () => void;
+  dataset: Dataset;
+  datasetUploadStatus: DatasetUploadStatus;
+}) {
+  let numOfConvertedFormats = 0;
+
+  for (const key of CONVERSION_STATUS_FORMAT_KEYS) {
+    if (datasetUploadStatus[key] !== CONVERSION_STATUS.CONVERTED) continue;
+
+    numOfConvertedFormats += 1;
+  }
+
+  let numOfAvailableFormats = 0;
+
+  if (dataset.dataset_deployments.length > 0) {
+    numOfAvailableFormats += 1;
+  }
+
+  numOfAvailableFormats = numOfAvailableFormats + dataset.dataset_assets.length;
+
+  useCheckCollection({
+    invalidateCollectionQuery,
+    shouldFetch: numOfConvertedFormats > numOfAvailableFormats,
+  });
+}
+
+const FETCH_COLLECTION_INTERVAL_MS = 5 * 1000;
+
+function useCheckCollection({
+  invalidateCollectionQuery,
+  shouldFetch,
+}: {
+  invalidateCollectionQuery: () => void;
+  shouldFetch: boolean;
+}) {
+  useEffect(() => {
+    let intervalId: number | undefined = undefined;
+
+    if (!intervalId && shouldFetch) {
+      intervalId = window?.setInterval(() => {
+        if (shouldFetch) {
+          invalidateCollectionQuery();
+        }
+      }, FETCH_COLLECTION_INTERVAL_MS);
+    }
+
+    return () => {
+      clearInterval(intervalId);
+    };
+  }, [invalidateCollectionQuery, shouldFetch]);
+}
+
+export function useCancelDatasetStatusQuery({
+  datasetId,
+  isFailed,
+  isLoading,
+  queryCache,
+}: {
+  datasetId: string;
+  isFailed: boolean;
+  isLoading: boolean;
+  queryCache: QueryCache;
+}) {
+  useEffect(() => {
+    if (isFailed || !isLoading) {
+      queryCache.cancelQueries([USE_DATASET_STATUS, datasetId]);
+    }
+  }, [datasetId, isFailed, isLoading, queryCache]);
+}
+
+export function useUploadProgress({
+  initProgress,
+  progress,
+}: {
+  initProgress: number;
+  progress: number;
+}) {
+  useProgress({
+    initProgress,
+    progress,
+    successCallback: useUploadProgressSuccessCallback,
+  });
+}
+
+function useUploadProgressSuccessCallback() {
+  successToast(
+    "Upload was successful. Your file is being processed which will " +
+      "continue in the background, even if you close this window."
+  );
+}
+
+export function getConversionStatus(datasetStatus?: DatasetUploadStatus) {
+  if (!datasetStatus) return CONVERSION_STATUS.NA;
+
+  const {
+    conversion_anndata_status,
+    conversion_cxg_status,
+    conversion_rds_status,
+    conversion_loom_status,
+  } = datasetStatus;
+
+  const statuses = [
+    conversion_anndata_status,
+    conversion_cxg_status,
+    conversion_rds_status,
+    conversion_loom_status,
+  ];
+
+  if (statuses.some((status) => status === CONVERSION_STATUS.CONVERTING)) {
+    return CONVERSION_STATUS.CONVERTING;
+  }
+
+  if (statuses.some((status) => status === CONVERSION_STATUS.FAILED)) {
+    return CONVERSION_STATUS.FAILED;
+  }
+
+  if (statuses.every((status) => status === CONVERSION_STATUS.CONVERTED)) {
+    return CONVERSION_STATUS.CONVERTED;
+  }
+
+  return CONVERSION_STATUS.NA;
+}
+
+export function useConversionProgress({
+  initDatasetStatus,
+  datasetStatus,
+}: {
+  initDatasetStatus: DatasetUploadStatus;
+  datasetStatus?: DatasetUploadStatus;
+}) {
+  const initProgress = isConverted(initDatasetStatus);
+  const progress = isConverted(datasetStatus);
+
+  useProgress({
+    initProgress,
+    progress,
+    successCallback: useConversionProgressSuccessCallback,
+  });
+}
+
+function useConversionProgressSuccessCallback() {
+  successToast("Processing complete.");
+}
+
+function isConverted(status?: DatasetUploadStatus): 0 | 1 {
+  return getConversionStatus(status) === CONVERSION_STATUS.CONVERTED ? 1 : 0;
+}
+
+export function hasCXGFile(dataset: Dataset) {
+  const deployments = dataset.dataset_deployments;
+
+  if (!deployments || !deployments.length) return false;
+
+  return true;
+}
+
+function successToast(message: string) {
+  DatasetUploadToast.show({
+    icon: IconNames.TICK,
+    intent: Intent.SUCCESS,
+    message,
+  });
+}
+
+function useProgress({
+  initProgress,
+  progress,
+  successCallback,
+}: {
+  initProgress: number;
+  progress: number;
+  successCallback: () => void;
+}) {
+  useEffect(() => {
+    if (initProgress === 1) return;
+
+    if (progress === 1) {
+      successCallback();
+    }
+  }, [successCallback, initProgress, progress]);
 }

--- a/frontend/src/components/common/theme.ts
+++ b/frontend/src/components/common/theme.ts
@@ -58,3 +58,11 @@ export enum RED {
   D = "#F55656",
   E = "#FF7373",
 }
+
+export enum ORANGE {
+  A = "#A66321",
+  B = "#BF7326",
+  C = "#D9822B",
+  D = "#F29D49",
+  E = "#FFB366",
+}

--- a/frontend/src/views/Collection/style.ts
+++ b/frontend/src/views/Collection/style.ts
@@ -1,5 +1,4 @@
-import { Alert, Classes } from "@blueprintjs/core";
-import { BLUE, PT_GRID_SIZE_PX, RED } from "src/components/common/theme";
+import { PT_GRID_SIZE_PX } from "src/components/common/theme";
 import styled from "styled-components";
 
 export const CollectionInfo = styled.div`
@@ -34,16 +33,5 @@ export const StyledDiv = styled.div`
   flex-direction: row;
   & > :not(:last-child) {
     margin-right: ${PT_GRID_SIZE_PX}px;
-  }
-`;
-
-export const StyledAlert = styled(Alert)`
-  .${Classes.BUTTON} {
-    background: ${RED.C};
-    box-shadow: none !important;
-    :not(.${Classes.INTENT_DANGER}) {
-      color: ${BLUE.C};
-      background: none;
-    }
   }
 `;

--- a/frontend/tests/features/homepage.test.ts
+++ b/frontend/tests/features/homepage.test.ts
@@ -1,5 +1,5 @@
 import { PROMPT_TEXT } from "src/components/Collections/components/Dataset/components/DownloadDataset/components/Content/components/Details";
-import { goToPage } from "tests/utils/helpers";
+import { goToPage, tryUntil } from "tests/utils/helpers";
 import { TEST_URL } from "../common/constants";
 import { getTestTag, getText } from "../utils/selectors";
 
@@ -45,19 +45,21 @@ describe("Homepage", () => {
       await expect(page).toHaveSelector(getText(PROMPT_TEXT));
     });
 
-    it("downloads a file", async () => {
+    it.only("downloads a file", async () => {
       await goToPage(TEST_URL);
 
       await page.click(getTestTag(DATASET_ROW_DOWNLOAD_BUTTON_ID));
 
       await page.click(getText(".h5ad (AnnData v0.7)"));
 
-      const downloadLink = await page.getAttribute(
-        getTestTag("download-asset-download-button"),
-        "href"
-      );
+      await tryUntil(async () => {
+        const downloadLink = await page.getAttribute(
+          getTestTag("download-asset-download-button"),
+          "href"
+        );
 
-      expect(downloadLink).toBeTruthy();
+        expect(downloadLink).toBeTruthy();
+      });
     });
   });
 });

--- a/frontend/tests/utils/helpers.ts
+++ b/frontend/tests/utils/helpers.ts
@@ -1,3 +1,26 @@
 export async function goToPage(url: string) {
   await page.goto(url);
 }
+
+export async function tryUntil(assert: () => void) {
+  const MAX_RETRY = 10;
+  const WAIT_FOR_MS = 200;
+
+  let retry = 0;
+
+  while (retry < MAX_RETRY) {
+    try {
+      await assert();
+
+      break;
+    } catch (error) {
+      retry += 1;
+
+      await page.waitForTimeout(WAIT_FOR_MS);
+    }
+  }
+
+  if (retry === MAX_RETRY) {
+    throw Error("tryUntil() assertion failed!");
+  }
+}


### PR DESCRIPTION
#### Reviewers
**Functional:** @seve 

**Readability:** @Bento007 (was thinking about Madison too, but eyes are important 👀 !!)

---

## Changes
- add

- remove

- modify

1. FE will poll dataset status endpoint for conversion status until all formats either become `CONVERTED` or `FAILED`. When CXG file becomes available, we also show the `Explore` button that takes users to its Explorer page

    <img width="1132" alt="Screen Shot 2021-01-20 at 10 23 54 AM" src="https://user-images.githubusercontent.com/6309723/105218164-abcb6900-5b09-11eb-88e6-b210cb5658a1.png">

1. Download dataset + cancel prompt

    @hthomas-czi @brianraymor : I didn't have time to implement the dropdown menu for downloading the files, because I realized last night that it would take maybe 2 more points to refactor the old code to play well with the new feature. 

    In the meantime, clicking on the "Download" button will trigger the existing download modal with unavailable formats disabled. If we need to implement the download dropdown menu, I can create a polish ticket for that! Thank you!

    Design:    
    <img width="335" alt="Screen Shot 2021-01-20 at 10 04 05 AM" src="https://user-images.githubusercontent.com/6309723/105216403-568e5800-5b07-11eb-8191-c5458e3fe484.png">

    Current implementation:    
    <img width="594" alt="Screen Shot 2021-01-20 at 10 04 21 AM" src="https://user-images.githubusercontent.com/6309723/105216431-6443dd80-5b07-11eb-9002-7c5479bc8f6b.png">

    ![demo](https://user-images.githubusercontent.com/6309723/105143812-39c73580-5ab1-11eb-87f6-184306ff6592.gif)

1. Orange warning:

    @hthomas-czi @brianraymor : I changed the text copy to be "one or more formats failed", because it's a lot more straightforward to implement it that way. But if we still need to list out the specific formats that fail, we can address it in a polish ticket? Thank you!

    <img width="968" alt="Screen Shot 2021-01-19 at 8 52 45 PM" src="https://user-images.githubusercontent.com/6309723/105215458-22fefe00-5b06-11eb-8e78-675fc7e468f9.png">

1. Show delete/cancel alert for both trashcan and inline cancel button:

    
    ![demo](https://user-images.githubusercontent.com/6309723/105220491-a6bbe900-5b0c-11eb-9b70-ae8313542fb0.gif)

1. UPDATE: Download Modal now has Blueprint buttons too:

    ![demo](https://user-images.githubusercontent.com/6309723/105254900-645bd180-5b37-11eb-8590-9bd6c8099c39.gif)

1. UPDATE: DeleteDataset cancel button now matches DownloadDataset's cancel button!

    ![demo](https://user-images.githubusercontent.com/6309723/105259733-311e4000-5b41-11eb-8a45-0d8a46a39eb8.gif)
