### PR TITLE
Quick simple mock auth server

### DIFF
--- a/backend/chalice/mock_auth_server/.chalice/config.json
+++ b/backend/chalice/mock_auth_server/.chalice/config.json
@@ -1,0 +1,12 @@
+{
+  "version": "2.0",
+  "app_name": "mock_auth_server",
+  "stages": {
+    "dev": {
+      "api_gateway_stage": "api",
+      "environment_variables": {
+        "DOMAIN": "https://glwbgfipn1.execute-api.us-west-2.amazonaws.com/api/"
+      }
+    }
+  }
+}

--- a/backend/chalice/mock_auth_server/.chalice/deployed/dev.json
+++ b/backend/chalice/mock_auth_server/.chalice/deployed/dev.json
@@ -1,0 +1,23 @@
+{
+  "resources": [
+    {
+      "name": "default-role",
+      "resource_type": "iam_role",
+      "role_arn": "arn:aws:iam::699936264352:role/mock_auth_server-dev",
+      "role_name": "mock_auth_server-dev"
+    },
+    {
+      "name": "api_handler",
+      "resource_type": "lambda_function",
+      "lambda_arn": "arn:aws:lambda:us-west-2:699936264352:function:mock_auth_server-dev"
+    },
+    {
+      "name": "rest_api",
+      "resource_type": "rest_api",
+      "rest_api_id": "glwbgfipn1",
+      "rest_api_url": "https://glwbgfipn1.execute-api.us-west-2.amazonaws.com/api/"
+    }
+  ],
+  "schema_version": "2.0",
+  "backend": "api"
+}

--- a/backend/chalice/mock_auth_server/.gitignore
+++ b/backend/chalice/mock_auth_server/.gitignore
@@ -1,0 +1,2 @@
+.chalice/deployments/
+.chalice/venv/

--- a/backend/chalice/mock_auth_server/app.py
+++ b/backend/chalice/mock_auth_server/app.py
@@ -1,0 +1,62 @@
+import os
+
+import jose.jwt
+import time
+from chalice import Chalice, Response
+
+app = Chalice(app_name="mock_auth_server")
+
+
+@app.route("/authorize")
+def api_authorize():
+    callback = app.current_request.query_params.get("redirect_uri")
+    state = app.current_request.query_params.get("state")
+    return Response(headers={"Location": f"{callback}?code=fakecode&state={state}"}, status_code=302)
+
+
+@app.route("/oauth/token")
+def api_oauth_token():
+    expires_at = time.time()
+    headers = dict(alg="RS256", kid="fake_kid")
+    payload = dict(
+        name="Fake User", sub="test_user_id", email="fake_user@email.com", email_verified=True, exp=expires_at
+    )
+
+    jwt = jose.jwt.encode(claims=payload, key="mysecret", algorithm="HS256", headers=headers)
+    r = {
+        "access_token": f"access-{time.time()}",
+        "id_token": jwt,
+        "refresh_token": f"random-{time.time()}",
+        "scope": "openid profile email offline",
+        "expires_in": TOKEN_EXPIRES,
+        "token_type": "Bearer",
+        "expires_at": expires_at,
+    }
+    return r
+
+
+@app.route("/v2/logout")
+def api_logout():
+    return_to = app.current_request.query_params.get("returnTo")
+    return Response(headers={"Location": return_to}, status_code=302)
+
+
+@app.route("/.well-known/openid-configuration")
+def api_openid_configuration():
+    data = dict(jwks_uri=f"{os.getenv('DOMAIN')}/.well-known/jwks.json")
+    return data
+
+
+@app.route("/.well-known/jwks.json")
+def api_jwks():
+    data = dict(
+        alg="RS256",
+        kty="RSA",
+        use="sig",
+        kid="fake_kid",
+    )
+    return dict(keys=[data])
+
+
+# seconds until the token expires
+TOKEN_EXPIRES = 3600

--- a/backend/chalice/mock_auth_server/app.py
+++ b/backend/chalice/mock_auth_server/app.py
@@ -14,7 +14,7 @@ def api_authorize():
     return Response(headers={"Location": f"{callback}?code=fakecode&state={state}"}, status_code=302)
 
 
-@app.route("/oauth/token")
+@app.route("/oauth/token", methods=['POST'], content_types=['application/x-www-form-urlencoded'])
 def api_oauth_token():
     expires_at = time.time()
     headers = dict(alg="RS256", kid="fake_kid")

--- a/backend/chalice/mock_auth_server/app.py
+++ b/backend/chalice/mock_auth_server/app.py
@@ -14,7 +14,7 @@ def api_authorize():
     return Response(headers={"Location": f"{callback}?code=fakecode&state={state}"}, status_code=302)
 
 
-@app.route("/oauth/token", methods=['POST'], content_types=['application/x-www-form-urlencoded'])
+@app.route("/oauth/token", methods=["POST"], content_types=["application/x-www-form-urlencoded"])
 def api_oauth_token():
     expires_at = time.time()
     headers = dict(alg="RS256", kid="fake_kid")

--- a/backend/chalice/mock_auth_server/requirements.txt
+++ b/backend/chalice/mock_auth_server/requirements.txt
@@ -1,0 +1,1 @@
+python-jose[cryptography]>=3.1.0


### PR DESCRIPTION
#### Reviewers
**Functional:** @MDunitz 

**Readability:** @seve 

---

## Changes
- add mock_auth_server
- The mock server lives at https://glwbgfipn1.execute-api.us-west-2.amazonaws.com/api/. 
- To use it in the backend, modify the keys "api_base_url" and  "callback_base_url" in `CorporaAuthConfig` to use "https://glwbgfipn1.execute-api.us-west-2.amazonaws.com/api". This can be done by modifying the secret in secrets manager