### PR TITLE
thuang-850-fix-download-button

### DIFF
--- a/frontend/src/common/modules/datasets/selectors.ts
+++ b/frontend/src/common/modules/datasets/selectors.ts
@@ -1,0 +1,7 @@
+import { Dataset } from "src/common/entities";
+
+export function hasAssets(dataset?: Dataset) {
+  if (!dataset) return false;
+
+  return Boolean(dataset?.dataset_assets?.length);
+}

--- a/frontend/src/components/Collections/components/Dataset/common/style.ts
+++ b/frontend/src/components/Collections/components/Dataset/common/style.ts
@@ -33,3 +33,13 @@ export const buttonStyle = css`
     cursor: pointer;
   }
 `;
+
+export const disabledButtonStyle = css`
+  color: rgb(0, 118, 220, 0.5);
+  border: 1px solid rgb(0, 118, 220, 0.2);
+
+  &:hover {
+    cursor: not-allowed;
+    background-color: white;
+  }
+`;

--- a/frontend/src/components/Collections/components/Dataset/components/DownloadDataset/style.ts
+++ b/frontend/src/components/Collections/components/Dataset/components/DownloadDataset/style.ts
@@ -1,6 +1,17 @@
+import { DARK_GRAY } from "src/components/common/theme";
 import styled from "styled-components";
 import { buttonStyle } from "../../common/style";
 
 export const StyledButton = styled.button`
   ${buttonStyle}
+
+  &:disabled {
+    border: 1px solid ${DARK_GRAY.A};
+    color: ${DARK_GRAY.A};
+
+    &:hover {
+      cursor: not-allowed;
+      background-color: white;
+    }
+  }
 `;

--- a/frontend/src/components/Collections/components/Dataset/components/DownloadDataset/style.ts
+++ b/frontend/src/components/Collections/components/Dataset/components/DownloadDataset/style.ts
@@ -1,17 +1,10 @@
-import { DARK_GRAY } from "src/components/common/theme";
 import styled from "styled-components";
-import { buttonStyle } from "../../common/style";
+import { buttonStyle, disabledButtonStyle } from "../../common/style";
 
 export const StyledButton = styled.button`
   ${buttonStyle}
 
   &:disabled {
-    border: 1px solid ${DARK_GRAY.A};
-    color: ${DARK_GRAY.A};
-
-    &:hover {
-      cursor: not-allowed;
-      background-color: white;
-    }
+    ${disabledButtonStyle}
   }
 `;

--- a/frontend/src/components/Collections/components/Dataset/index.tsx
+++ b/frontend/src/components/Collections/components/Dataset/index.tsx
@@ -3,6 +3,7 @@ import {
   Collection as ICollection,
   Dataset as IDataset,
 } from "src/common/entities";
+import { hasAssets } from "src/common/modules/datasets/selectors";
 import DownloadDataset from "./components/DownloadDataset";
 import MoreInformation from "./components/MoreInformation";
 import ViewDataset from "./components/ViewDataset";
@@ -21,6 +22,7 @@ const Dataset: FC<Props> = ({ dataset, links }) => {
       </Name>
       <ViewDataset deployments={dataset.dataset_deployments} />
       <DownloadDataset
+        isDisabled={!hasAssets(dataset)}
         name={dataset.name}
         dataAssets={dataset.dataset_assets}
       />

--- a/frontend/src/views/Collection/index.tsx
+++ b/frontend/src/views/Collection/index.tsx
@@ -146,7 +146,7 @@ const Collection: FC<Props> = ({ id = "" }) => {
             </Button>
           </DropboxChooser>
           <DownloadDataset
-            isDisabled={!selectedDataset}
+            isDisabled={!hasDatasetAssets(selectedDataset)}
             name={selectedDataset?.name || ""}
             dataAssets={selectedDataset?.dataset_assets || []}
             Button={DownloadButton}
@@ -174,6 +174,12 @@ function getSelectedDataset({
   datasets: Dataset[];
 }) {
   return datasets.find((dataset) => dataset.id === selectedId);
+}
+
+function hasDatasetAssets(dataset?: Dataset) {
+  if (!dataset) return false;
+
+  return Boolean(dataset?.dataset_assets?.length);
 }
 
 export default Collection;

--- a/frontend/src/views/Collection/index.tsx
+++ b/frontend/src/views/Collection/index.tsx
@@ -10,6 +10,7 @@ import {
   Link,
   VISIBILITY_TYPE,
 } from "src/common/entities";
+import { hasAssets } from "src/common/modules/datasets/selectors";
 import {
   useCollection,
   useCollectionUploadLinks,
@@ -146,7 +147,7 @@ const Collection: FC<Props> = ({ id = "" }) => {
             </Button>
           </DropboxChooser>
           <DownloadDataset
-            isDisabled={!hasDatasetAssets(selectedDataset)}
+            isDisabled={!hasAssets(selectedDataset)}
             name={selectedDataset?.name || ""}
             dataAssets={selectedDataset?.dataset_assets || []}
             Button={DownloadButton}
@@ -174,12 +175,6 @@ function getSelectedDataset({
   datasets: Dataset[];
 }) {
   return datasets.find((dataset) => dataset.id === selectedId);
-}
-
-function hasDatasetAssets(dataset?: Dataset) {
-  if (!dataset) return false;
-
-  return Boolean(dataset?.dataset_assets?.length);
 }
 
 export default Collection;


### PR DESCRIPTION
#850 

#### Reviewers
**Functional:** 
@seve 

**Readability:** 
@MDunitz 

---

## Changes
- add
  - Add selector `hasAssets()` to only enable the Download button if `true`
  - Add new folder and file `frontend/src/common/modules/datasets/selectors.ts `

- modify
  - Disable download button if no asset is available for download

Homepage:
<img width="1407" alt="Screen Shot 2021-01-25 at 1 26 42 PM" src="https://user-images.githubusercontent.com/6309723/105768526-59c38280-5f11-11eb-9839-f97a655b9ece.png">

![demo](https://user-images.githubusercontent.com/6309723/105768588-6ea01600-5f11-11eb-89ef-ac6c87bac2bd.gif)


Collection Page:
![demo](https://user-images.githubusercontent.com/6309723/105768486-503a1a80-5f11-11eb-891b-3c1b9cd44056.gif)

UPDATE (1/26):
New disabled style:

<img width="221" alt="Screen Shot 2021-01-26 at 1 44 48 PM" src="https://user-images.githubusercontent.com/6309723/105909941-09195b80-5fdd-11eb-91c6-17c8700ae645.png">
