### PR TITLE
Thuang 804 publish private collection

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1155,11 +1155,11 @@
       "dev": true
     },
     "@blueprintjs/core": {
-      "version": "3.34.1",
-      "resolved": "https://registry.npmjs.org/@blueprintjs/core/-/core-3.34.1.tgz",
-      "integrity": "sha512-wCGjzI04ajbpoD/c4R5xJMMdDSyclpc19eHcDpKbsN0ruFWr0Soe8up8bLZfe8VXj51BUj7K2psJblPsCLHgnA==",
+      "version": "3.38.1",
+      "resolved": "https://registry.npmjs.org/@blueprintjs/core/-/core-3.38.1.tgz",
+      "integrity": "sha512-ZBqVfMgeIrXiuprsRxBnLM/MPgPSCRf27uckyhMFHRocyEtFS7zrOGmQeJb1Va0nZ/ufNsYk7EiHVxulb1KkSg==",
       "requires": {
-        "@blueprintjs/icons": "^3.22.0",
+        "@blueprintjs/icons": "^3.24.0",
         "@types/dom4": "^2.0.1",
         "classnames": "^2.2",
         "dom4": "^2.1.5",
@@ -1212,9 +1212,9 @@
           }
         },
         "debug": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.2.0.tgz",
-          "integrity": "sha512-IX2ncY78vDTjZMFUdmsvIRFY2Cf4FnD0wRs+nQwJU8Lu99/tPFdb0VybiiMTPe3I6rQmwsqQqRBvxU+bZ/I8sg==",
+          "version": "4.3.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+          "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
           "dev": true,
           "requires": {
             "ms": "2.1.2"
@@ -1223,9 +1223,9 @@
       }
     },
     "@blueprintjs/icons": {
-      "version": "3.22.0",
-      "resolved": "https://registry.npmjs.org/@blueprintjs/icons/-/icons-3.22.0.tgz",
-      "integrity": "sha512-clfdwRQlzqs2sDxjwQr4p10Z3bGNTnqpsLgN+4TN1ECf7plEEukhvQh6YK/Lfd5xDhEBEEZ/YQCawZbyAYjfXg==",
+      "version": "3.24.0",
+      "resolved": "https://registry.npmjs.org/@blueprintjs/icons/-/icons-3.24.0.tgz",
+      "integrity": "sha512-OvDDI5EUueS1Y3t594iS8LAGoHhLhYjC2GuN/01a85n+ASLSp0jf0/+uix2JeCOj41iTdRRCINbWuRwVQNNGPw==",
       "requires": {
         "classnames": "^2.2",
         "tslib": "~1.13.0"
@@ -8713,9 +8713,9 @@
       "integrity": "sha512-6QvTW9mrGeIegrFXdtQi9pk7O/nSK6lSdXW2eqUspN5LWD7UTji2Fqw5V2YLjBpHEoU9Xl/eUWNpDeZvoyOv2w=="
     },
     "dom4": {
-      "version": "2.1.5",
-      "resolved": "https://registry.npmjs.org/dom4/-/dom4-2.1.5.tgz",
-      "integrity": "sha512-gJbnVGq5zaBUY0lUh0LUEVGYrtN75Ks8ZwpwOYvnVFrKy/qzXK4R/1WuLIFExWj/tBxbRAkTzZUGJHXmqsBNjQ=="
+      "version": "2.1.6",
+      "resolved": "https://registry.npmjs.org/dom4/-/dom4-2.1.6.tgz",
+      "integrity": "sha512-JkCVGnN4ofKGbjf5Uvc8mmxaATIErKQKSgACdBXpsQ3fY6DlIpAyWfiBSrGkttATssbDCp3psiAKWXk5gmjycA=="
     },
     "domain-browser": {
       "version": "1.2.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -5,8 +5,8 @@
   "version": "0.1.0",
   "author": "Kyle Mathews <mathews.kyle@gmail.com>",
   "dependencies": {
-    "@blueprintjs/core": "^3.34.1",
-    "@blueprintjs/icons": "^3.22.0",
+    "@blueprintjs/core": "^3.38.1",
+    "@blueprintjs/icons": "^3.24.0",
     "@loadable/component": "^5.14.0",
     "babel-plugin-styled-components": "^1.11.1",
     "bl": "^4.0.3",

--- a/frontend/src/common/API.ts
+++ b/frontend/src/common/API.ts
@@ -5,6 +5,7 @@ export enum API {
   COLLECTIONS = "/dp/v1/collections",
   COLLECTION = "/dp/v1/collections/{id}",
   COLLECTION_UPLOAD_LINKS = "/dp/v1/collections/{id}/upload-links",
+  COLLECTION_PUBLISH = "/dp/v1/collections/{id}/publish",
   CREATE_COLLECTION = "/dp/v1/collections",
   LOG_IN = "/dp/v1/login",
   LOG_OUT = "/dp/v1/logout",

--- a/frontend/src/common/queries/collections.ts
+++ b/frontend/src/common/queries/collections.ts
@@ -183,3 +183,34 @@ export function useDeleteCollection(id = "") {
     },
   });
 }
+
+async function publishCollection(id: Collection["id"]) {
+  if (!id) {
+    throw Error("No id given");
+  }
+
+  const url = apiTemplateToUrl(API_URL + API.COLLECTION_PUBLISH, { id });
+
+  const response = await fetch(url, {
+    ...DEFAULT_FETCH_OPTIONS,
+    method: "POST",
+  });
+
+  const result = await response.json();
+
+  if (!response.ok) {
+    throw result;
+  }
+}
+
+export function usePublishCollection() {
+  const queryCache = useQueryCache();
+
+  return useMutation(publishCollection, {
+    onSuccess: () => {
+      // (thuang): We don't need to invalidate `[USE_COLLECTION, id, visibility]`
+      // because `visibility` has changed from PRIVATE to PUBLIC
+      queryCache.invalidateQueries([USE_COLLECTIONS]);
+    },
+  });
+}

--- a/frontend/src/components/Alert/index.ts
+++ b/frontend/src/components/Alert/index.ts
@@ -6,7 +6,7 @@ export default styled(Alert)`
   width: ${PT_GRID_SIZE_PX * 55}px;
   line-height: 18px;
   .${Classes.BUTTON} {
-    :not(.${Classes.INTENT_DANGER}) {
+    :not(.${Classes.INTENT_DANGER}):not(.${Classes.INTENT_PRIMARY}) {
       background: none;
       box-shadow: none !important;
       color: ${DARK_GRAY.A};

--- a/frontend/src/components/Collections/components/DeleteCollection/index.tsx
+++ b/frontend/src/components/Collections/components/DeleteCollection/index.tsx
@@ -1,6 +1,6 @@
 import { Button, H6, Intent } from "@blueprintjs/core";
 import { IconNames } from "@blueprintjs/icons";
-import { navigate } from "@reach/router";
+import { useNavigate } from "@reach/router";
 import React, { FC, useState } from "react";
 import { ROUTES } from "src/common/constants/routes";
 import { Collection } from "src/common/entities";
@@ -12,11 +12,13 @@ interface Props {
 }
 
 const DeleteCollection: FC<Props> = ({ id }) => {
-  const [deleteMutation] = useDeleteCollection(id);
+  const [deleteMutation, { isSuccess }] = useDeleteCollection(id);
+  const navigate = useNavigate();
 
-  const handleDelete = async () => {
-    await deleteMutation(id);
-    navigate(ROUTES.MY_COLLECTIONS);
+  if (isSuccess) navigate(ROUTES.MY_COLLECTIONS);
+
+  const handleDelete = () => {
+    deleteMutation(id);
   };
 
   const [isOpen, setIsOpen] = useState(false);

--- a/frontend/src/components/Collections/components/DeleteCollection/index.tsx
+++ b/frontend/src/components/Collections/components/DeleteCollection/index.tsx
@@ -14,8 +14,8 @@ interface Props {
 const DeleteCollection: FC<Props> = ({ id }) => {
   const [deleteMutation] = useDeleteCollection(id);
 
-  const handleDelete = () => {
-    deleteMutation(id);
+  const handleDelete = async () => {
+    await deleteMutation(id);
     navigate(ROUTES.MY_COLLECTIONS);
   };
 

--- a/frontend/src/components/Collections/components/DeleteCollection/index.tsx
+++ b/frontend/src/components/Collections/components/DeleteCollection/index.tsx
@@ -1,12 +1,16 @@
 import { Button, H6, Intent } from "@blueprintjs/core";
 import { IconNames } from "@blueprintjs/icons";
+import loadable from "@loadable/component";
 import { useNavigate } from "@reach/router";
 import React, { FC, useState } from "react";
 import { ROUTES } from "src/common/constants/routes";
 import { Collection } from "src/common/entities";
 import { useDeleteCollection } from "src/common/queries/collections";
-import Alert from "src/components/Alert";
 
+const AsyncAlert = loadable(
+  () =>
+    /*webpackChunkName: 'src/components/Alert' */ import("src/components/Alert")
+);
 interface Props {
   id: Collection["id"];
 }
@@ -27,6 +31,10 @@ const DeleteCollection: FC<Props> = ({ id }) => {
     setIsOpen(!isOpen);
   };
 
+  const handleHover = () => {
+    AsyncAlert.preload();
+  };
+
   return (
     <>
       <Button
@@ -35,26 +43,29 @@ const DeleteCollection: FC<Props> = ({ id }) => {
         text="Delete"
         icon={IconNames.TRASH}
         onClick={toggleAlert}
+        onMouseEnter={handleHover}
       />
 
-      <Alert
-        cancelButtonText={"Cancel"}
-        confirmButtonText={"Delete Collection"}
-        intent={Intent.DANGER}
-        isOpen={isOpen}
-        onCancel={toggleAlert}
-        onConfirm={() => {
-          handleDelete();
-          toggleAlert();
-        }}
-      >
-        <H6>Are you sure you want to delete this collection?</H6>
-        <p>
-          Deleting this collection will also delete any uploaded datasets. If
-          you’ve shared this collection or its datasets with anyone, they will
-          also lose access. You cannot undo this action.
-        </p>
-      </Alert>
+      {isOpen && (
+        <AsyncAlert
+          cancelButtonText={"Cancel"}
+          confirmButtonText={"Delete Collection"}
+          intent={Intent.DANGER}
+          isOpen={isOpen}
+          onCancel={toggleAlert}
+          onConfirm={() => {
+            handleDelete();
+            toggleAlert();
+          }}
+        >
+          <H6>Are you sure you want to delete this collection?</H6>
+          <p>
+            Deleting this collection will also delete any uploaded datasets. If
+            you’ve shared this collection or its datasets with anyone, they will
+            also lose access. You cannot undo this action.
+          </p>
+        </AsyncAlert>
+      )}
     </>
   );
 };

--- a/frontend/src/components/Collections/components/Grid/components/Row/DatasetRow/components/DeleteDataset/index.tsx
+++ b/frontend/src/components/Collections/components/Grid/components/Row/DatasetRow/components/DeleteDataset/index.tsx
@@ -1,8 +1,13 @@
 import { Button as RawButton, H6, Intent } from "@blueprintjs/core";
 import { IconNames } from "@blueprintjs/icons";
+import loadable from "@loadable/component";
 import React, { FC, useState } from "react";
 import { useDeleteDataset } from "src/common/queries/datasets";
-import Alert from "src/components/Alert";
+
+const AsyncAlert = loadable(
+  () =>
+    /*webpackChunkName: 'src/components/Alert' */ import("src/components/Alert")
+);
 
 interface Props {
   id?: string;
@@ -23,23 +28,29 @@ const DeleteDataset: FC<Props> = ({
     setIsOpen(!isOpen);
   };
 
+  const handleHover = () => {
+    AsyncAlert.preload();
+  };
+
   return (
     <>
-      <Button disabled={!id} onClick={toggleAlert} />
-      <Alert
-        cancelButtonText={"Cancel"}
-        confirmButtonText={"Delete Dataset"}
-        intent={Intent.DANGER}
-        isOpen={isOpen}
-        onCancel={toggleAlert}
-        onConfirm={() => {
-          deleteDataset(id);
-          toggleAlert();
-        }}
-      >
-        <H6>Are you sure you want to delete this dataset?</H6>
-        <p>You cannot undo this action</p>
-      </Alert>
+      <Button onMouseEnter={handleHover} disabled={!id} onClick={toggleAlert} />
+      {isOpen && (
+        <AsyncAlert
+          cancelButtonText={"Cancel"}
+          confirmButtonText={"Delete Dataset"}
+          intent={Intent.DANGER}
+          isOpen={isOpen}
+          onCancel={toggleAlert}
+          onConfirm={() => {
+            deleteDataset(id);
+            toggleAlert();
+          }}
+        >
+          <H6>Are you sure you want to delete this dataset?</H6>
+          <p>You cannot undo this action</p>
+        </AsyncAlert>
+      )}
     </>
   );
 };

--- a/frontend/src/components/Collections/components/Grid/components/Row/DatasetRow/index.tsx
+++ b/frontend/src/components/Collections/components/Grid/components/Row/DatasetRow/index.tsx
@@ -17,7 +17,6 @@ import {
 import { UploadingFile } from "src/components/DropboxChooser";
 import CellCount from "./components/CellCount";
 import Popover from "./components/Popover";
-import UploadStatus from "./components/UploadStatus";
 import { StyledRadio, TitleContainer } from "./style";
 import {
   checkIfCancelled,
@@ -38,6 +37,13 @@ const AsyncTooltip = loadable(
   () =>
     /*webpackChunkName: 'Grid/Row/DatasetRow/Tooltip' */ import(
       "./components/Tooltip"
+    )
+);
+
+const AsyncUploadStatus = loadable(
+  () =>
+    /*webpackChunkName: 'Grid/Row/DatasetRow/UploadStatus' */ import(
+      "./components/UploadStatus"
     )
 );
 
@@ -150,7 +156,7 @@ const DatasetRow: FC<Props> = ({
           )}
         </TitleContainer>
         {isLoading && (
-          <UploadStatus
+          <AsyncUploadStatus
             isConverting={
               getConversionStatus(datasetStatus) ===
               CONVERSION_STATUS.CONVERTING

--- a/frontend/src/components/Collections/components/PublishCollection/index.tsx
+++ b/frontend/src/components/Collections/components/PublishCollection/index.tsx
@@ -1,0 +1,76 @@
+import { Button, H6, Intent } from "@blueprintjs/core";
+import loadable from "@loadable/component";
+import { useNavigate } from "@reach/router";
+import React, { FC, useState } from "react";
+import { ROUTES } from "src/common/constants/routes";
+import { Collection } from "src/common/entities";
+import { usePublishCollection } from "src/common/queries/collections";
+
+const AsyncAlert = loadable(
+  () =>
+    /*webpackChunkName: 'src/components/Alert' */ import("src/components/Alert")
+);
+
+interface Props {
+  id: Collection["id"];
+  isPublishable: boolean;
+}
+
+const PublishCollection: FC<Props> = ({ id = "", isPublishable }) => {
+  const [isOpen, setIsOpen] = useState(false);
+  const [publish, { isSuccess, isLoading }] = usePublishCollection();
+  const navigate = useNavigate();
+
+  if (isSuccess) {
+    navigate(ROUTES.COLLECTION.replace(":id", id));
+  }
+
+  const toggleAlert = () => setIsOpen(!isOpen);
+
+  const handleConfirm = async () => {
+    await publish(id);
+    toggleAlert();
+  };
+
+  const handleHover = () => {
+    AsyncAlert.preload();
+  };
+
+  const handleClick = () => {
+    setIsOpen(!isOpen);
+  };
+
+  return (
+    <>
+      <Button
+        onMouseEnter={handleHover}
+        onClick={handleClick}
+        intent={Intent.PRIMARY}
+        text="Publish"
+        disabled={!isPublishable}
+        data-test-id="publish-collection-button"
+      />
+      {isOpen && (
+        <AsyncAlert
+          cancelButtonText={"Cancel"}
+          confirmButtonText={"Publish Collection"}
+          intent={Intent.PRIMARY}
+          isOpen={isOpen}
+          onCancel={toggleAlert}
+          onConfirm={handleConfirm}
+          loading={isLoading}
+        >
+          <H6>Are you sure you want to publish this collection?</H6>
+          <p>
+            The datasets, related metadata, and CXG(s) in this collection will
+            be viewable and downloadable by all portal users. External sites may
+            directly link to the CXG(s).
+          </p>
+          <p>This action cannot be undone without manual intervention.</p>
+        </AsyncAlert>
+      )}
+    </>
+  );
+};
+
+export default PublishCollection;

--- a/frontend/src/views/Collection/index.tsx
+++ b/frontend/src/views/Collection/index.tsx
@@ -1,29 +1,23 @@
-import { Button, Classes, H3, Intent } from "@blueprintjs/core";
+import { Button, H3, Intent } from "@blueprintjs/core";
 import { IconNames } from "@blueprintjs/icons";
 import { RouteComponentProps } from "@reach/router";
 import { memoize } from "lodash-es";
 import React, { FC, useState } from "react";
 import { useQueryCache } from "react-query";
-import {
-  COLLECTION_LINK_TYPE_OPTIONS,
-  Dataset,
-  Link,
-  VISIBILITY_TYPE,
-} from "src/common/entities";
+import { Dataset, VISIBILITY_TYPE } from "src/common/entities";
 import { hasAssets } from "src/common/modules/datasets/selectors";
 import {
   useCollection,
   useCollectionUploadLinks,
   USE_COLLECTION,
 } from "src/common/queries/collections";
-import { getUrlHost } from "src/common/utils/getUrlHost";
 import DownloadDataset from "src/components/Collections/components/Dataset/components/DownloadDataset";
 import DeleteCollection from "src/components/Collections/components/DeleteCollection";
 import DatasetsGrid from "src/components/Collections/components/Grid/components/DatasetsGrid";
 import DeleteDataset from "src/components/Collections/components/Grid/components/Row/DatasetRow/components/DeleteDataset";
+import PublishCollection from "src/components/Collections/components/PublishCollection";
 import DropboxChooser, { UploadingFile } from "src/components/DropboxChooser";
 import { ViewGrid } from "../globalStyle";
-import { StyledLink } from "./common/style";
 import DatasetUploadToast from "./components/DatasetUploadToast";
 import EmptyDatasets from "./components/EmptyDatasets";
 import {
@@ -34,6 +28,12 @@ import {
   LinkContainer,
   StyledDiv,
 } from "./style";
+import {
+  DownloadButton,
+  getIsPublishable,
+  getSelectedDataset,
+  renderLinks,
+} from "./utils";
 
 interface RouteProps {
   id?: string;
@@ -41,32 +41,13 @@ interface RouteProps {
 
 export type Props = RouteComponentProps<RouteProps>;
 
-const renderLinks = (links: Link[]) => {
-  return links?.map(({ link_url: url, link_type: type }) => {
-    const linkTypeOption = COLLECTION_LINK_TYPE_OPTIONS[type];
-
-    if (!linkTypeOption) return null;
-
-    const urlHost = getUrlHost(url);
-
-    const { text } = linkTypeOption;
-
-    if (!urlHost) return null;
-
-    return (
-      <React.Fragment key={`${type}+${url}`}>
-        <span className={Classes.TEXT_MUTED}>{text}</span>
-        <StyledLink href={url}>{urlHost}</StyledLink>
-      </React.Fragment>
-    );
-  });
-};
 export interface UploadedFiles {
   [datasetID: string]: UploadingFile;
 }
 
 const Collection: FC<Props> = ({ id = "" }) => {
   const isPrivate = window.location.pathname.includes("/private");
+
   const visibility = isPrivate
     ? VISIBILITY_TYPE.PRIVATE
     : VISIBILITY_TYPE.PUBLIC;
@@ -107,8 +88,12 @@ const Collection: FC<Props> = ({ id = "" }) => {
     return null;
   }
 
+  const datasets = collection.datasets;
+
   const isDatasetPresent =
-    collection.datasets?.length > 0 || Object.keys(uploadedFiles).length > 0;
+    datasets?.length > 0 || Object.keys(uploadedFiles).length > 0;
+
+  const isPublishable = getIsPublishable(datasets);
 
   const invalidateCollectionQuery = memoize(
     () => {
@@ -118,7 +103,7 @@ const Collection: FC<Props> = ({ id = "" }) => {
   );
 
   const selectedDataset = getSelectedDataset({
-    datasets: collection.datasets,
+    datasets,
     selectedId: selected,
   });
 
@@ -139,12 +124,14 @@ const Collection: FC<Props> = ({ id = "" }) => {
           disabled
           text="Share"
         />
-        <Button intent={Intent.PRIMARY} disabled text="Publish" />
+        {isPrivate && (
+          <PublishCollection isPublishable={isPublishable} id={id} />
+        )}
       </CollectionButtons>
       <DatasetContainer>
         {isDatasetPresent ? (
           <DatasetsGrid
-            datasets={collection.datasets}
+            datasets={datasets}
             uploadedFiles={uploadedFiles}
             invalidateCollectionQuery={invalidateCollectionQuery}
             onSelect={setSelected}
@@ -172,23 +159,5 @@ const Collection: FC<Props> = ({ id = "" }) => {
     </ViewGrid>
   );
 };
-
-function DownloadButton({ ...props }) {
-  return (
-    <Button intent={Intent.PRIMARY} outlined {...props}>
-      Download
-    </Button>
-  );
-}
-
-function getSelectedDataset({
-  selectedId,
-  datasets,
-}: {
-  selectedId: string;
-  datasets: Dataset[];
-}) {
-  return datasets.find((dataset) => dataset.id === selectedId);
-}
 
 export default Collection;

--- a/frontend/src/views/Collection/utils.tsx
+++ b/frontend/src/views/Collection/utils.tsx
@@ -1,0 +1,65 @@
+import { Button, Classes, Intent } from "@blueprintjs/core";
+import React from "react";
+import {
+  Collection,
+  COLLECTION_LINK_TYPE_OPTIONS,
+  Dataset,
+  DATASET_ASSET_FORMAT,
+  Link,
+} from "src/common/entities";
+import { getUrlHost } from "src/common/utils/getUrlHost";
+import { StyledLink } from "./common/style";
+
+export function renderLinks(links: Link[]) {
+  return links?.map(({ link_url: url, link_type: type }) => {
+    const linkTypeOption = COLLECTION_LINK_TYPE_OPTIONS[type];
+
+    if (!linkTypeOption) return null;
+
+    const urlHost = getUrlHost(url);
+
+    const { text } = linkTypeOption;
+
+    if (!urlHost) return null;
+
+    return (
+      <React.Fragment key={`${type}+${url}`}>
+        <span className={Classes.TEXT_MUTED}>{text}</span>
+        <StyledLink href={url}>{urlHost}</StyledLink>
+      </React.Fragment>
+    );
+  });
+}
+
+export function DownloadButton({ ...props }) {
+  return (
+    <Button intent={Intent.PRIMARY} outlined {...props}>
+      Download
+    </Button>
+  );
+}
+
+export function getSelectedDataset({
+  selectedId,
+  datasets,
+}: {
+  selectedId: string;
+  datasets: Dataset[];
+}) {
+  return datasets.find((dataset) => dataset.id === selectedId);
+}
+
+export function getIsPublishable(datasets: Collection["datasets"]) {
+  return (
+    Boolean(datasets?.length) &&
+    datasets.every((dataset) => {
+      const numOfAssets = dataset.dataset_assets.length;
+      const numOfDeployments = dataset.dataset_deployments.length;
+
+      return (
+        numOfAssets + numOfDeployments ===
+        Object.keys(DATASET_ASSET_FORMAT).length
+      );
+    })
+  );
+}

--- a/frontend/tests/features/collection.test.ts
+++ b/frontend/tests/features/collection.test.ts
@@ -1,11 +1,12 @@
 import { ROUTES } from "src/common/constants/routes";
 import { apiTemplateToUrl } from "src/common/utils/apiTemplateToUrl";
 import { API_URL } from "src/configs/configs";
-import { TEST_ENV, TEST_URL } from "tests/common/constants";
-import { goToPage } from "tests/utils/helpers";
-import { getText } from "tests/utils/selectors";
+import { goToPage, login } from "tests/utils/helpers";
+import { getTestTag, getText } from "tests/utils/selectors";
 
-const describeIfCalledByDevEnv = TEST_ENV === "dev" ? describe : describe.skip;
+// (thuang): TEMP
+// Use `TEST_ENV.includes("local")` later
+const describeIfDeployed = describe.skip;
 
 const TEST_COLLECTION = {
   contactEmail: "TEST@example.com",
@@ -14,42 +15,62 @@ const TEST_COLLECTION = {
   name: "TEST COLLECTION",
 };
 
-describeIfCalledByDevEnv("Collection", async () => {
-  it("creates and deletes a collection", async () => {
-    await goToPage(TEST_URL);
-    // LOG IN
-    await page.click(getText("Log In"));
-    await page.waitForNavigation({ url: TEST_URL, waitUntil: "networkidle" });
-    // Create collection
-    await page.click(getText("Create Collection"));
-    await page.fill("#name", TEST_COLLECTION.name);
-    await page.fill("#description", TEST_COLLECTION.description);
-    await page.fill("#contact-name", TEST_COLLECTION.contactName);
-    await page.fill("#contact-email", TEST_COLLECTION.contactEmail);
-    await page.click(
-      getText("I agree to cellxgene's data submission policies.")
-    );
-    const [, response] = await Promise.all([
-      page.waitForEvent("request"),
-      page.waitForEvent("response"),
-      await page.click(getText("Create")),
-    ]);
+describe("Collection", async () => {
+  describeIfDeployed("Logged In Tests", () => {
+    it("creates and deletes a collection", async () => {
+      await login();
 
-    const { collectionID } = (await response.json()) as {
-      collectionID: string;
-    };
+      const collectionId = await createCollection();
 
-    await expect(page).toHaveText(TEST_COLLECTION.name);
+      // Try delete
+      await page.click("Delete");
+      await page.click("Delete Collection");
 
-    // Try delete
-    await page.click("Delete");
-    await page.click("Delete Collection");
+      await goToPage(
+        apiTemplateToUrl(API_URL + ROUTES.PRIVATE_COLLECTION, {
+          id: collectionId,
+        })
+      );
+      await expect(page).not.toHaveText(TEST_COLLECTION.name);
+    });
 
-    await goToPage(
-      apiTemplateToUrl(API_URL + ROUTES.PRIVATE_COLLECTION, {
-        id: collectionID,
-      })
-    );
-    await expect(page).not.toHaveText(TEST_COLLECTION.name);
+    describe("Publish a collection", () => {
+      describe("when no dataset", () => {
+        it("shows disabled publish button", async () => {
+          await login();
+
+          await createCollection();
+
+          const publishButton = await page.$(
+            getTestTag("publish-collection-button")
+          );
+
+          expect(publishButton?.getAttribute("disabled")).toBe("");
+        });
+      });
+    });
   });
 });
+
+async function createCollection(): Promise<string> {
+  await page.click(getText("Create Collection"));
+  await page.fill("#name", TEST_COLLECTION.name);
+  await page.fill("#description", TEST_COLLECTION.description);
+  await page.fill("#contact-name", TEST_COLLECTION.contactName);
+  await page.fill("#contact-email", TEST_COLLECTION.contactEmail);
+  await page.click(getText("I agree to cellxgene's data submission policies."));
+
+  const [, response] = await Promise.all([
+    page.waitForEvent("request"),
+    page.waitForEvent("response"),
+    await page.click(getText("Create")),
+  ]);
+
+  const { collectionId } = (await response.json()) as {
+    collectionId: string;
+  };
+
+  await expect(page).toHaveText(TEST_COLLECTION.name);
+
+  return collectionId;
+}

--- a/frontend/tests/features/collection.test.ts
+++ b/frontend/tests/features/collection.test.ts
@@ -7,14 +7,12 @@ import { getText } from "tests/utils/selectors";
 
 const describeIfCalledByDevEnv = TEST_ENV === "dev" ? describe : describe.skip;
 
-/*  eslint-disable sort-keys */
 const TEST_COLLECTION = {
-  name: "TEST COLLECTION",
-  description: "TEST DESCRIPTION",
-  contactName: "TEST NAME",
   contactEmail: "TEST@example.com",
+  contactName: "TEST NAME",
+  description: "TEST DESCRIPTION",
+  name: "TEST COLLECTION",
 };
-/* eslint-enable sort-keys */
 
 describeIfCalledByDevEnv("Collection", async () => {
   it("creates and deletes a collection", async () => {

--- a/frontend/tests/features/homepage.test.ts
+++ b/frontend/tests/features/homepage.test.ts
@@ -1,13 +1,12 @@
 import { PROMPT_TEXT } from "src/components/Collections/components/Dataset/components/DownloadDataset/components/Content/components/Details";
 import { goToPage, tryUntil } from "tests/utils/helpers";
-import { TEST_URL } from "../common/constants";
 import { getTestTag, getText } from "../utils/selectors";
 
 const DATASET_ROW_DOWNLOAD_BUTTON_ID = "dataset-download-button";
 
 describe("Homepage", () => {
   it("renders the expected elements", async () => {
-    await goToPage(TEST_URL);
+    await goToPage();
 
     await expect(page).toHaveSelector(getText("cellxgene@chanzuckerberg.com"));
     await expect(page).toHaveSelector(getTestTag("logo"));
@@ -25,7 +24,7 @@ describe("Homepage", () => {
 
   describe("renders the download dataset modal", () => {
     it("renders the default content", async () => {
-      await goToPage(TEST_URL);
+      await goToPage();
 
       await page.click(getTestTag(DATASET_ROW_DOWNLOAD_BUTTON_ID));
 
@@ -46,7 +45,7 @@ describe("Homepage", () => {
     });
 
     it("downloads a file", async () => {
-      await goToPage(TEST_URL);
+      await goToPage();
 
       await page.click(getTestTag(DATASET_ROW_DOWNLOAD_BUTTON_ID));
 

--- a/frontend/tests/utils/helpers.ts
+++ b/frontend/tests/utils/helpers.ts
@@ -1,9 +1,18 @@
-export async function goToPage(url: string) {
+import { TEST_URL } from "tests/common/constants";
+import { getText } from "./selectors";
+
+export async function goToPage(url: string = TEST_URL) {
   await page.goto(url);
 }
 
+export async function login(url: string = TEST_URL) {
+  await goToPage(url);
+  await page.click(getText("Log In"));
+  await page.waitForNavigation({ url, waitUntil: "networkidle" });
+}
+
 export async function tryUntil(assert: () => void) {
-  const MAX_RETRY = 10;
+  const MAX_RETRY = 50;
   const WAIT_FOR_MS = 200;
 
   let retry = 0;


### PR DESCRIPTION
#804 

#### Reviewers
**Functional:** 
@seve 

**Readability:** 
@Bento007 

---

## Changes
- add
1. `COLLECTION_PUBLISH` API
2. `publishCollection()` and `usePublishCollection()`
3. Add `<PublishCollection />`
4. Add "Publish a collection" test 

- modify
1. Upgrade BlueprintJS, so the Alert modal gets a `loading` state
2. Update `<Alert />` component styling to show Primary button properly 
3. Code split `<Alert />` from `<DeleteCollection />`, `<DeleteDataset />`, and `<DatasetRow />`
4. Move some `views/Collection`'s helper functions into `frontend/src/views/Collection/utils.tsx`
5. Refactor some shared helper functions into `frontend/tests/utils/helpers.ts`
 

1. **Published collection is showing the green tag:**
    <img width="1249" alt="Screen Shot 2021-02-01 at 11 17 51 AM" src="https://user-images.githubusercontent.com/6309723/106506978-4bc8b100-647f-11eb-88a2-464d68781982.png">

1. **Empty dataset Publish button is disabled:**
    <img width="1234" alt="Screen Shot 2021-02-01 at 11 18 08 AM" src="https://user-images.githubusercontent.com/6309723/106506986-4cf9de00-647f-11eb-8b58-ea637bbd8a71.png">

1. **Public collection Publish button is hidden:**
    <img width="1239" alt="Screen Shot 2021-02-01 at 11 18 30 AM" src="https://user-images.githubusercontent.com/6309723/106506988-4d927480-647f-11eb-80fe-6afc3304ebad.png">

1. **Private collection Publish button is disabled when there are failed datasets:**
    <img width="1240" alt="Screen Shot 2021-02-01 at 11 22 26 AM" src="https://user-images.githubusercontent.com/6309723/106507417-e0331380-647f-11eb-8b8b-4e2fe7a320b3.png">

1. Demo:

    
![Kapture 2021-02-01 at 13 19 45](https://user-images.githubusercontent.com/6309723/106520034-02815d00-6491-11eb-868c-8cd0aac73ed4.gif)
