### PR TITLE
link_name is blank if not populated in DB

### DIFF
--- a/backend/corpora/common/entities/collection.py
+++ b/backend/corpora/common/entities/collection.py
@@ -134,7 +134,7 @@ class Collection(Entity):
         for hidden in ["user", "owner", "tombstone"]:
             result.pop(hidden, None)
         result["links"] = [
-            dict(link_url=link["link_url"], link_name=link["link_name"] or "", link_type=link["link_type"])
+            dict(link_url=link["link_url"], link_name=link.get("link_name", ""), link_type=link["link_type"])
             for link in result["links"]
         ]
 

--- a/tests/unit/backend/chalice/api_server/test_v1_collection.py
+++ b/tests/unit/backend/chalice/api_server/test_v1_collection.py
@@ -348,7 +348,7 @@ class TestCollection(BaseAuthAPITest, GenerateDataMixin):
             "contact_email": "person@human.com",
             "data_submission_policy_version": "0.0.1",
             "links": [
-                {"link_name": "DOI Link", "link_url": "http://doi.org/10.1016", "link_type": "DOI"},
+                {"link_url": "http://doi.org/10.1016", "link_type": "OTHER"},
                 {"link_name": "DOI Link 2", "link_url": "http://doi.org/10.1017", "link_type": "DOI"},
             ],
         }


### PR DESCRIPTION
#### Reviewers
**Functional:** @tihuan 

**Readability:** @seve 

---

## Changes
- modify how collection link names are populated in API responses.
