### PR TITLE
Improving database migration documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -143,3 +143,4 @@ dmypy.json
 .terraform
 .envrc
 .env.ecr
+*.sqlc

--- a/README.md
+++ b/README.md
@@ -45,6 +45,9 @@ See [DEV_ENV.md](DEV_ENV.md) for the local development guide.
 1. [Deploy Cloudfront-invalidator](backend/chalice/cloudfront_invalidator/README.md#Deploy)
 1. [Deploy Frontend](frontend/README.md#Deployment)
 
+### Database Procedures
+see [Data Portal Database Procedures](backend/database/README.md)
+
 ### Running unittests
 
 1. Set `AWS_PROFILE`

--- a/backend/Makefile
+++ b/backend/Makefile
@@ -53,12 +53,12 @@ db/download:
     # Download the database to corpora_dev-<date>.sqlc
 	$(eval DB_PW = $(shell aws secretsmanager get-secret-value --secret-id corpora/backend/${DEPLOYMENT_STAGE}/database --region us-west-2 | jq -r '.SecretString | split(":") | .[-1] | split("@") | .[0]'))
 	$(eval OUTFILE = $(shell date +corpora_${DEPLOYMENT_STAGE}-%Y%m%d%H%M.sqlc))
-	PGPASSWORD=${DB_PW} pg_dump -Fc --dbname=corpora_${DEPLOYMENT_STAGE} --file=${OUTFILE} --host 0.0.0.0 --username corpora_${DEPLOYMENT_STAGE}
+	PGPASSWORD=${DB_PW} pg_dump -Fc --dbname=corpora_${DEPLOYMENT_STAGE} --file=database/${OUTFILE} --host 0.0.0.0 --username corpora_${DEPLOYMENT_STAGE}
 
 db/import:
     # Imports corpora_dev.sqlc into the corpora_test database
 	# Usage: make db/import FROM=dev
-	pg_restore --clean --no-owner --dbname corpora_test corpora_$(FROM).sqlc
+	docker-compose exec database pg_restore --clean --no-owner --username corpora --dbname corpora /import/$(FROM).sqlc
 
 db/import/schema:
     # Imports the corpora_dev.sqlc schema (schema ONLY) into the corpora_test database
@@ -68,13 +68,12 @@ db/import/schema:
 	pg_restore --data-only --table=alembic_version --no-owner --dbname corpora_test corpora_$(DEPLOYMENT_STAGE).sqlc
 
 db/dump_schema:
-ifeq ($(DEPLOYMENT_STAGE),"test")
-	pg_dump --schema-only --dbname=corpora_test
+ifeq ($(DEPLOYMENT_STAGE),test)
+	docker-compose exec database pg_dump --schema-only --dbname=corpora --username corpora
 else
 	$(eval DB_PW = $(shell aws secretsmanager get-secret-value --secret-id corpora/backend/${DEPLOYMENT_STAGE}/database --region us-west-2 | jq -r '.SecretString | split(":") | .[-1] | split("@") | .[0]'))
 	PGPASSWORD=${DB_PW} pg_dump --schema-only --dbname corpora_${DEPLOYMENT_STAGE} --username corpora_${DEPLOYMENT_STAGE} --host 0.0.0.0
 endif
-
 
 db/test_migration:
 	$(MAKE) db/dump_schema > /tmp/before

--- a/backend/database/README.md
+++ b/backend/database/README.md
@@ -9,6 +9,7 @@
 1. Run `make db/new_migration MESSAGE="purpose_of_migration"` where `purpose_of_migration` is a short phrase describing why the database migration is occurring.
 1. Head over to the file that was just created. The path will be something like `backend/database/versions/xxxxxxxxxxxx_purpose_of_migration.py`. Edit the `upgrade()` and `downgrade()` functions such that `upgrade()` contains the commands to perform the migration you would like and `downgrade()` contains the commands to undo it.
 1. [Test your migration](#test-a-migration)
+1. Check that [corpora.orm](../corpora/common/corpora_orm.py) matches up with your changes.
 1. Once you've completed the changes, create a PR to get the functions reviewed. 
 1. Once the PR is merged, you can run the migration.
 1. [Connect to Remote RDS](#connect-to-remote-rds)

--- a/backend/database/README.md
+++ b/backend/database/README.md
@@ -1,33 +1,79 @@
-## Data Portal Database Procedures
+# Data Portal Database Procedures
 
-General information about Alembic migrations can be found [here](https://alembic.sqlalchemy.org/en/latest/index.html).
+- General information about Alembic migrations can be found [here](https://alembic.sqlalchemy.org/en/latest/index.html).
+- For database [make recipes](../Makefile)
 
-### How to perform a database migration
+## How to perform a database migration
 
 1. From the top level directory (`corpora-data-portal`), `cd backend`.
 1. Run `make db/new_migration MESSAGE="purpose_of_migration"` where `purpose_of_migration` is a short phrase describing why the database migration is occurring.
 1. Head over to the file that was just created. The path will be something like `backend/database/versions/xxxxxxxxxxxx_purpose_of_migration.py`. Edit the `upgrade()` and `downgrade()` functions such that `upgrade()` contains the commands to perform the migration you would like and `downgrade()` contains the commands to undo it.
-1. Enable local connection to the private `dev` RDS instance through Bastion: `make db/tunnel`. See [Connect to Remote RDS](#connect_to_remote_rds) for more details.
-1. Once you've completed the changes (and at this point, you can create a PR to get the functions reviewed), test your migration. Ensure that you are [connected](https://github.com/chanzuckerberg/corpora-data-portal/blob/main/backend/chalice/api_server/README.md#development) to the database you'd like to migrate (usually `TEST`). Run `DEPLOYMENT_STAGE=test make db/migrate`.
-1. If no errors are outputted, complete the migration by running `DEPLOYMENT_STAGE=dev make db/migrate`. Ensure that tunneling is set up and `CORPORA_LOCAL_DEV` is set to true.
+1. [Test your migration](#test-a-migration)
+1. Once you've completed the changes, create a PR to get the functions reviewed. 
+1. Once the PR is merged, you can run the migration.
+1. [Connect to Remote RDS](#connect-to-remote-rds)
+1. In a new terminal, complete the migration by running:
+```shell
+cd corpora-data-portal/backend
+export CORPORA_LOCAL_DEV=1
+export DEPLOYMENT_STAGE=dev 
+make db/migrate
+```
 
-### How to autogenerate migration script
+## How to autogenerate migration script
 
 1. From the top level directory (`corpora-data-portal`), `cd backend`.
-1. Makes changes to [corpora_orm.py](../corpora/common/corpora_orm.py)
-1. Set DEPLOYMENT_STAGE=dev, CORPORA_LOCAL_DEV=1
-1. Run `make db/connect`
-1. Follow [How to perform a database migration](#how_to_perform_a_database_migration) instructions except use `make db/new_migration_auto MESSAGE="purpose_of_migration"`. See [What does Autogenerate Detect (and what does it not detect?)](https://alembic.sqlalchemy.org/en/latest/autogenerate.html#what-does-autogenerate-detect-and-what-does-it-not-detect).
+1. Make changes to [corpora_orm.py](../corpora/common/corpora_orm.py)
+1. [Connect to Remote RDS](#connect-to-remote-rds)
+1. Run Auto-migration:
+```shell
+cd corpora-data-portal/backend
+export CORPORA_LOCAL_DEV=1
+export DEPLOYMENT_STAGE=dev 
+make db/new_migration_auto MESSAGE="purpose_of_migration"
+```
+See [What does Autogenerate Detect (and what does it not detect?)](https://alembic.sqlalchemy.org/en/latest/autogenerate.html#what-does-autogenerate-detect-and-what-does-it-not-detect).
+5. Follow [How to perform a database migration](#how-to-perform-a-database-migration) starting from **step 3**.
+
+### Test a Migration
+The following steps will test that a migration script works on a local database using data downloaded from a deployed database. 
+
+1. [Connect to Remote RDS](#connect-to-remote-rds)
+2. Open a new terminal and download the remote database schema:
+```shell
+cd corpora-data-portal/backend
+export DEPLOYMENT_STAGE=dev
+make db/download
+```
+This wll download the database into a file ending in *.sqlc*.
+3. Close the tunnel to the remote database
+4. Start the local database environment: 
+```shell
+cd corpora-data-portal
+make local-start
+export DEPLOYMENT_STAGE=test
+```
+5. Import the remote database schema into your local database:  
+```shell
+make db/import FROM=${}
+```
+where from is the name of the *.sqlc* file downloaded. You may need to run this a few times, until there are no significant errors.
+1. Run the migration test:
+```shell
+make db/test_migration
+``` 
+If there are no differences then the test passed. If the test didn't pass, make adjustments to your migration script and restart from step 5. Repeat until there are no errors.
 
 ## Connect to Remote RDS
 Enable local connection to the private RDS instance:
 
-```Shell
+```shell
 cd ./corpora-data-poral/backend
+export DEPLOYMENT_STAGE=dev
 make db/tunnel
 ```
 
-This command opens an SSH tunnel from `localhost:5432` to the RDS connection endpoint via the `bastion` server.
+This command opens an SSH tunnel from `localhost:5432` to the RDS connection endpoint via the *bastion* server.
 The local port `5432` is fixed and encoded in the DB connection string stored in the AWS Secret at
 `corpora/backend/<DEPLOYMENT_STAGE>/database_local`.
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,7 @@ services:
       - POSTGRES_PASSWORD=test_pw
     volumes:
       - database:/var/lib/postgresql/data
+      - ./backend/database:/import
   localstack:
     image: localstack/localstack@sha256:7c6635493185d25165979995fb073fd789c72b6d8b17ef3a70b798d55576732f
     ports:


### PR DESCRIPTION

#### Reviewers
**Functional:** @jgadling 

**Readability:** @MDunitz 

---

## Changes
- Modify documentation to work with the current architecture.
- Add explicit instruction for testing a migration locally. 
- Modify database make recipes to work with database docker container
- Add an additional volume to the database container so we can import a *.sqlc into the database docker container using make db/import.