### PR TITLE
Add Default False to tombstones

### DIFF
--- a/backend/corpora/common/corpora_orm.py
+++ b/backend/corpora/common/corpora_orm.py
@@ -172,7 +172,7 @@ class DbCollection(Base, AuditMixin):
     contact_name = Column(String, default="")
     contact_email = Column(String, default="")
     data_submission_policy_version = Column(String, nullable=False)
-    tombstone = Column(Boolean, default=False)
+    tombstone = Column(Boolean, default=False, nullable=False)
 
     # Relationships
     links = relationship("DbProjectLink", back_populates="collection", cascade="all, delete-orphan")
@@ -229,7 +229,7 @@ class DbDataset(Base, AuditMixin):
     is_valid = Column(Boolean, default=False)
     collection_id = Column(String, nullable=False)
     collection_visibility = Column(Enum(CollectionVisibility), nullable=False)
-    tombstone = Column(Boolean, default=False)
+    tombstone = Column(Boolean, default=False, nullable=False)
 
     # Relationships
     collection = relationship("DbCollection", uselist=False, back_populates="datasets")

--- a/backend/database/versions/5a363594dd06_tombstone_false.py
+++ b/backend/database/versions/5a363594dd06_tombstone_false.py
@@ -10,8 +10,8 @@ import sqlalchemy as sa
 
 
 # revision identifiers, used by Alembic.
-revision = '5a363594dd06'
-down_revision = '9a900b8ee3a5'
+revision = "5a363594dd06"
+down_revision = "9a900b8ee3a5"
 branch_labels = None
 depends_on = None
 
@@ -21,10 +21,10 @@ def upgrade():
         op.execute(f"UPDATE {table} SET {column} = {default}")
         op.alter_column(table, column, nullable=False)
 
-    tombstone_false('dataset', 'tombstone', False)
-    tombstone_false('project', 'tombstone', False)
+    tombstone_false("dataset", "tombstone", False)
+    tombstone_false("project", "tombstone", False)
 
 
 def downgrade():
-    op.alter_column('dataset', 'tombstone', nullable=True)
-    op.alter_column('project', 'tombstone', nullable=True)
+    op.alter_column("dataset", "tombstone", nullable=True)
+    op.alter_column("project", "tombstone", nullable=True)

--- a/backend/database/versions/5a363594dd06_tombstone_false.py
+++ b/backend/database/versions/5a363594dd06_tombstone_false.py
@@ -1,0 +1,30 @@
+"""tombstone_false
+
+Revision ID: 5a363594dd06
+Revises: 9a900b8ee3a5
+Create Date: 2021-02-08 16:45:25.402786
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '5a363594dd06'
+down_revision = '9a900b8ee3a5'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    def tombstone_false(table: str, column: str, default):
+        op.execute(f"UPDATE {table} SET {column} = {default}")
+        op.alter_column(table, column, nullable=False)
+
+    tombstone_false('dataset', 'tombstone', False)
+    tombstone_false('project', 'tombstone', False)
+
+
+def downgrade():
+    op.alter_column('dataset', 'tombstone', nullable=True)
+    op.alter_column('project', 'tombstone', nullable=True)

--- a/backend/database/versions/5a363594dd06_tombstone_false.py
+++ b/backend/database/versions/5a363594dd06_tombstone_false.py
@@ -6,7 +6,6 @@ Create Date: 2021-02-08 16:45:25.402786
 
 """
 from alembic import op
-import sqlalchemy as sa
 
 
 # revision identifiers, used by Alembic.


### PR DESCRIPTION
#### Reviewers
**Functional:** @MDunitz 

**Readability:** @tihuan 

---

## Changes
- add tombstone false to all existing datasets and collections.
- modify tombstone in datasets and collection to be required and defaulted to false
