### PR TITLE
Dunitz/830 collection deletion

### DIFF
--- a/backend/config/corpora-api.yml
+++ b/backend/config/corpora-api.yml
@@ -151,12 +151,15 @@ paths:
       summary: Delete a collection
       security:
         - cxguserCookie: [ ]
+        - dummyAuth: [ ]
       description: >-
         Deletes an entire private collection from cellxgene data-portal, including any generated artifacts/assets and
         deployments.
       operationId: corpora.lambdas.api.v1.collection_uuid.delete
       parameters:
         - $ref: "#/components/parameters/path_collection_uuid"
+        - $ref: "#/components/parameters/query_visibility"
+
       responses:
         "202":
           $ref: "#/components/responses/202"

--- a/backend/config/corpora-api.yml
+++ b/backend/config/corpora-api.yml
@@ -155,7 +155,7 @@ paths:
       description: >-
         Deletes an entire private collection from cellxgene data-portal, including any generated artifacts/assets and
         deployments.
-      operationId: corpora.lambdas.api.v1.collection_uuid.delete
+      operationId: corpora.lambdas.api.v1.collection.delete_collection
       parameters:
         - $ref: "#/components/parameters/path_collection_uuid"
         - $ref: "#/components/parameters/query_visibility"

--- a/backend/config/corpora-api.yml
+++ b/backend/config/corpora-api.yml
@@ -151,15 +151,12 @@ paths:
       summary: Delete a collection
       security:
         - cxguserCookie: [ ]
-        - dummyAuth: [ ]
       description: >-
         Deletes an entire private collection from cellxgene data-portal, including any generated artifacts/assets and
         deployments.
       operationId: corpora.lambdas.api.v1.collection.delete_collection
       parameters:
         - $ref: "#/components/parameters/path_collection_uuid"
-        - $ref: "#/components/parameters/query_visibility"
-
       responses:
         "202":
           $ref: "#/components/responses/202"

--- a/backend/corpora/common/entities/collection.py
+++ b/backend/corpora/common/entities/collection.py
@@ -3,6 +3,7 @@ from datetime import datetime
 
 from sqlalchemy import and_
 
+from . import Dataset
 from ..utils.db_session import clone
 from .entity import Entity
 from ..corpora_orm import DbCollection, DbCollectionLink, CollectionVisibility
@@ -109,6 +110,7 @@ class Collection(Entity):
         """
 
         filters = filters if filters else []
+        filters.append(cls.table.tombstone == False)
         list_attributes = list_attributes if list_attributes else cls.list_attributes
         table = cls.table
 
@@ -172,5 +174,8 @@ class Collection(Entity):
 
     def tombstone_collection(self):
         self.update(tombstone=True)
+
         for dataset in self.datasets:
-            dataset.dataset_and_asset_deletion()
+            ds = Dataset.get(self.session, dataset.id, include_tombstones=True)
+            ds.dataset_and_asset_deletion()
+

--- a/backend/corpora/common/entities/collection.py
+++ b/backend/corpora/common/entities/collection.py
@@ -57,8 +57,9 @@ class Collection(Entity):
         return cls(new_db_object)
 
     @classmethod
-    def get_collection(cls, session, collection_uuid, visibility=CollectionVisibility.PUBLIC.name,
-                       include_tombstones=False):
+    def get_collection(
+        cls, session, collection_uuid, visibility=CollectionVisibility.PUBLIC.name, include_tombstones=False
+    ):
         """
         Given the collection_uuid, retrieve a live collection.
         :param collection_uuid:
@@ -68,7 +69,6 @@ class Collection(Entity):
             if collection and collection.tombstone is True:
                 return None
         return collection
-
 
     @classmethod
     def if_owner(
@@ -178,4 +178,3 @@ class Collection(Entity):
         for dataset in self.datasets:
             ds = Dataset.get(self.session, dataset.id, include_tombstones=True)
             ds.dataset_and_asset_deletion()
-

--- a/backend/corpora/common/entities/collection.py
+++ b/backend/corpora/common/entities/collection.py
@@ -110,7 +110,7 @@ class Collection(Entity):
         """
 
         filters = filters if filters else []
-        filters.append(cls.table.tombstone == False)
+        filters.append(cls.table.tombstone == False)  # noqa
         list_attributes = list_attributes if list_attributes else cls.list_attributes
         table = cls.table
 

--- a/backend/corpora/lambdas/api/v1/collection.py
+++ b/backend/corpora/lambdas/api/v1/collection.py
@@ -68,3 +68,16 @@ def create_collection(body: object, user: str):
 
 def get_collection_dataset(dataset_uuid: str):
     raise NotImplementedError
+
+
+def delete_collection(collection_uuid: str, visibility: str, user: str):
+    if visibility == CollectionVisibility.PUBLIC.name:
+        return make_response(jsonify("Can not delete a public dataset"), 405)
+    collection = Collection.get_collection(collection_uuid, visibility)
+    if not collection:
+        raise ForbiddenHTTPException()
+    if not Collection.if_owner(collection.uuid, collection.visibility, user):
+        raise ForbiddenHTTPException()
+    if not collection.tombstone:
+        collection.tombstone_collection()
+    return "", 202

--- a/backend/corpora/lambdas/api/v1/collection.py
+++ b/backend/corpora/lambdas/api/v1/collection.py
@@ -70,11 +70,11 @@ def get_collection_dataset(dataset_uuid: str):
     raise NotImplementedError
 
 
-def delete_collection(collection_uuid: str, visibility: str, user: str):
-    if visibility == CollectionVisibility.PUBLIC.name:
-        return make_response(jsonify("Can not delete a public dataset"), 405)
+def delete_collection(collection_uuid: str, user: str):
     db_session = g.db_session
-    collection = Collection.get_collection(db_session, collection_uuid, visibility, include_tombstones=True)
+    collection = Collection.get_collection(
+        db_session, collection_uuid, CollectionVisibility.PRIVATE.name, include_tombstones=True
+    )
     if not collection:
         raise ForbiddenHTTPException()
     if not Collection.if_owner(db_session, collection.id, collection.visibility, user):

--- a/backend/corpora/lambdas/api/v1/collection.py
+++ b/backend/corpora/lambdas/api/v1/collection.py
@@ -73,10 +73,11 @@ def get_collection_dataset(dataset_uuid: str):
 def delete_collection(collection_uuid: str, visibility: str, user: str):
     if visibility == CollectionVisibility.PUBLIC.name:
         return make_response(jsonify("Can not delete a public dataset"), 405)
-    collection = Collection.get_collection(collection_uuid, visibility)
+    db_session = g.db_session
+    collection = Collection.get_collection(db_session, collection_uuid, visibility, include_tombstones=True)
     if not collection:
         raise ForbiddenHTTPException()
-    if not Collection.if_owner(collection.uuid, collection.visibility, user):
+    if not Collection.if_owner(db_session, collection.id, collection.visibility, user):
         raise ForbiddenHTTPException()
     if not collection.tombstone:
         collection.tombstone_collection()

--- a/tests/unit/backend/corpora/common/entities/test_collection.py
+++ b/tests/unit/backend/corpora/common/entities/test_collection.py
@@ -197,3 +197,6 @@ class TestCollection(DataPortalTestCase):
         test_collection = Collection.create(self.session, **BogusCollectionParams.get())
         response = test_collection.reshape_for_api()
         self.assertEqual([], response["datasets"])
+
+    def test_tombstone_collection_tombstones_all_datasets_in_collection(self):
+        pass

--- a/tests/unit/backend/corpora/common/entities/test_collection.py
+++ b/tests/unit/backend/corpora/common/entities/test_collection.py
@@ -199,4 +199,21 @@ class TestCollection(DataPortalTestCase):
         self.assertEqual([], response["datasets"])
 
     def test_tombstone_collection_tombstones_all_datasets_in_collection(self):
-        pass
+        collection = self.generate_collection(
+            self.session, visibility=CollectionVisibility.PRIVATE.name, owner="test_user_id"
+        )
+        self.generate_dataset(self.session, collection=collection)
+        self.generate_dataset(self.session, collection=collection)
+
+        self.assertEqual(len(collection.datasets), 2)
+        for dataset in collection.datasets:
+            self.assertFalse(dataset.tombstone)
+        self.assertFalse(collection.tombstone)
+
+        collection.tombstone_collection()
+
+        self.assertTrue(collection.tombstone)
+
+        self.assertEqual(len(collection.datasets), 2)
+        for dataset in collection.datasets:
+            self.assertTrue(dataset.tombstone)


### PR DESCRIPTION
#### Reviewers
**Functional:** 

@Bento007 

**Readability:** 

@seve 
---

## Changes
- add endpoint to tombstone collections
### Definition of Done
- The collection will no longer appear in the list of private Collections nor public collections
- The collection cannot be retrieved by the user
- Datasets that were in the collection cannot be retrieved.
- Artifacts cannot be download from direct links
- Get collection return 403 for a deleted collection
- Get dataset/status returns 403 for a deleted dataset
- Return status 202 to confirm the deleted or if the collection has already been deleted.