### PR TITLE
Don't do work on module import

### DIFF
--- a/backend/corpora/common/utils/db_session.py
+++ b/backend/corpora/common/utils/db_session.py
@@ -12,10 +12,11 @@ logger = logging.getLogger(__name__)
 
 
 class DBSessionMaker:
-    engine = create_engine(CorporaDbConfig().database_uri, connect_args={"connect_timeout": 5})
+
     _session_make = None
 
     def __init__(self):
+        self.engine = create_engine(CorporaDbConfig().database_uri, connect_args={"connect_timeout": 5})
         if not self._session_make:
             self._session_make = sessionmaker(bind=self.engine)
 

--- a/backend/corpora/common/utils/db_session.py
+++ b/backend/corpora/common/utils/db_session.py
@@ -14,9 +14,11 @@ logger = logging.getLogger(__name__)
 class DBSessionMaker:
 
     _session_make = None
+    engine = None
 
     def __init__(self):
-        self.engine = create_engine(CorporaDbConfig().database_uri, connect_args={"connect_timeout": 5})
+        if not self.engine:
+            self.engine = create_engine(CorporaDbConfig().database_uri, connect_args={"connect_timeout": 5})
         if not self._session_make:
             self._session_make = sessionmaker(bind=self.engine)
 


### PR DESCRIPTION
create_engine() is being called as soon as this module is imported. Is this intentional?

#### Reviewers
**Functional:** 

**Readability:** 

---

## Changes
- add
- remove
- modify
