### PR TITLE
allow non owners to access private collections

### DIFF
--- a/backend/corpora/lambdas/api/v1/collection.py
+++ b/backend/corpora/lambdas/api/v1/collection.py
@@ -40,8 +40,6 @@ def get_collection_details(collection_uuid: str, visibility: str, user: str):
 
     if user == collection.owner:
         access_type = "WRITE"
-    elif visibility != CollectionVisibility.PUBLIC.name:
-        raise ForbiddenHTTPException()
     else:
         access_type = "READ"
     result = collection.reshape_for_api()

--- a/tests/unit/backend/chalice/api_server/test_v1_collection.py
+++ b/tests/unit/backend/chalice/api_server/test_v1_collection.py
@@ -382,7 +382,7 @@ class TestCollection(BaseAuthAPITest):
         test_url = furl(path=f"/dp/v1/collections/{collection_uuid}")
         test_url.add(query_params=dict(visibility="PRIVATE"))
         response = self.app.get(test_url.url, no_cookie_headers)
-        self.assertEqual("READ", json.loads(response.body)['access_type'])
+        self.assertEqual("READ", json.loads(response.body)["access_type"])
 
     def test__list_collection__check_owner(self):
 

--- a/tests/unit/backend/chalice/api_server/test_v1_collection.py
+++ b/tests/unit/backend/chalice/api_server/test_v1_collection.py
@@ -280,10 +280,7 @@ class TestCollection(BaseAuthAPITest):
 
         # run
         for auth, owns, visi, obfu in test_cases:
-            if obfu or (visi == "private" and owns and auth) or (visi == "public"):
-                expected_response_code = 200
-            else:
-                expected_response_code = 403
+            expected_response_code = 200
 
             test_collection_id = test_collections["_".join([visi, "owned" if owns else "not_owner"])]
             expected_access_type = "WRITE" if owns and auth else "READ"
@@ -380,12 +377,12 @@ class TestCollection(BaseAuthAPITest):
         self.assertEqual(body["contact_name"], body["contact_name"])
         self.assertEqual(body["contact_email"], body["contact_email"])
 
-        # test that non owners cant access
+        # test that non owners only have read access
         no_cookie_headers = {"host": "localhost", "Content-Type": "application/json"}
         test_url = furl(path=f"/dp/v1/collections/{collection_uuid}")
         test_url.add(query_params=dict(visibility="PRIVATE"))
         response = self.app.get(test_url.url, no_cookie_headers)
-        self.assertEqual(403, response.status_code)
+        self.assertEqual("READ", json.loads(response.body)['access_type'])
 
     def test__list_collection__check_owner(self):
 


### PR DESCRIPTION
#### Reviewers
**Functional:** 
- @Bento007 

**Readability:** 
- @seve 
---

## Changes
- modify collections endpoint to allow non owners to have read access 

## Definition of Done (from ticket)
When a non-owner visits a private collection link, they should still see the page, even though they don't have WRITE access. But they shouldn't see WRITE access related actions, such as Publish

## QA steps (optional)
