### PR TITLE
thuang-fix-collection-test

### DIFF
--- a/frontend/tests/features/collection.test.ts
+++ b/frontend/tests/features/collection.test.ts
@@ -26,11 +26,18 @@ describe("Collection", () => {
 
       // Try delete
       await page.click(getText("Delete"));
-      await page.click(getText("Delete Collection"));
 
-      await goToPage(
-        TEST_URL + ROUTES.PRIVATE_COLLECTION.replace(":id", collectionId)
-      );
+      await Promise.all([
+        page.waitForNavigation({ waitUntil: "networkidle" }),
+        await page.click(getText("Delete Collection")),
+      ]);
+
+      await Promise.all([
+        page.waitForNavigation({ waitUntil: "networkidle" }),
+        await goToPage(
+          TEST_URL + ROUTES.PRIVATE_COLLECTION.replace(":id", collectionId)
+        ),
+      ]);
 
       await expect(page).not.toHaveSelector(getText(TEST_COLLECTION.name), {
         timeout: TIMEOUT_MS,

--- a/frontend/tests/utils/helpers.ts
+++ b/frontend/tests/utils/helpers.ts
@@ -1,7 +1,7 @@
 import { TEST_EMAIL, TEST_URL } from "../common/constants";
 import { getText } from "./selectors";
 
-export const TIMEOUT_MS = 5 * 1000;
+export const TIMEOUT_MS = 3 * 1000;
 
 export async function goToPage(url: string = TEST_URL) {
   await page.goto(url);


### PR DESCRIPTION
#### Reviewers
**Functional:** 
@seve 

**Readability:** 
@Bento007 

---

## Changes
- add
- remove
- modify
1. Update test code to prevent race condition

The problem we had before is that right after clicking on the delete button, we immediately navigate to the private collection page without waiting for the success API callback. This means the collection page sometimes will still be there, since the BE hasn't deleted the collection yet, thus failing the test.

The solution is to wait for navigations!

## Definition of Done (from ticket)

## QA steps (optional)
