### PR TITLE
Dunitz/910 geneset post endpoint

### DIFF
--- a/backend/config/corpora-api.yml
+++ b/backend/config/corpora-api.yml
@@ -232,7 +232,7 @@ paths:
               properties:
                 genesets:
                   description: A list of genesets including their gene symbols and descriptions
-                  $ref: "#/components/schemas/gene_sets"
+                  $ref: "#/components/schemas/user_defined_gene_sets"
       responses:
         "200":
           description: OK
@@ -241,7 +241,7 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: "#/components/schemas/geneset"
+                  $ref: "#/components/schemas/gene_set"
         "400":
           $ref: "#/components/responses/400"
         "403":
@@ -559,7 +559,7 @@ components:
         genesets:
           type: array
           items:
-            $ref : "#/components/schemas/geneset"
+            $ref : "#/components/schemas/gene_set"
     ontology_element:
       type: object
       properties:
@@ -644,7 +644,7 @@ components:
           enum: [REMIX, ORIGINAL]
         s3_uri:
           type: string
-    geneset:
+    gene_set:
       type: object
       properties:
         name:
@@ -667,7 +667,7 @@ components:
           type: string
         detail:
           type: string
-    gene_sets:
+    user_defined_gene_sets:
       type: object
       description: User created geneset information
       properties:

--- a/backend/config/corpora-api.yml
+++ b/backend/config/corpora-api.yml
@@ -668,10 +668,29 @@ components:
         detail:
           type: string
     gene_sets:
-      type: array
-      items:
-        type: array
-        items: { }
+      type: object
+      description: User created geneset information
+      properties:
+        gene_set_name:
+          type: string
+        gene_set_description:
+          type: string
+        genes:
+          type: array
+          items:
+            type: object
+            description: Gene specific information
+            properties:
+              gene_symbol:
+                type:
+                  string
+              gene_description:
+                type:
+                  string
+              additional_params:
+                type:
+                  object
+
   parameters:
     path_collection_uuid:
       name: collection_uuid

--- a/backend/config/corpora-api.yml
+++ b/backend/config/corpora-api.yml
@@ -211,6 +211,43 @@ paths:
         "413":
           $ref: "#/components/responses/413"
 
+  /dp/v1/collections/{collection_uuid}/genesets:
+    post:
+      tags:
+        - collections
+        - genesets
+      summary: Add genesets to a collection
+      security:
+        - cxguserCookie: []
+      description: >-
+        Add genesets to a private collection
+      operationId: corpora.lambdas.api.v1.collection_uuid.gene_sets.post
+      parameters:
+        - $ref: "#/components/parameters/path_collection_uuid"
+        - $ref: "#components/schema/gene_sets"
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  dataset_uuid:
+                    $ref: "#/components/schemas/dataset_uuid"
+                  presigned_url:
+                    type: string
+                  file_name:
+                    type: string
+                  file_size:
+                    type: number
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+
   /dp/v1/collections/{collection_uuid}/publish:
     post:
       tags:

--- a/backend/config/corpora-api.yml
+++ b/backend/config/corpora-api.yml
@@ -242,12 +242,11 @@ paths:
                 type: array
                 items:
                   $ref: "#/components/schemas/geneset"
-        "401":
-          $ref: "#/components/responses/401"
+        "400":
+          $ref: "#/components/responses/400"
         "403":
           $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
+
 
   /dp/v1/collections/{collection_uuid}/publish:
     post:

--- a/backend/config/corpora-api.yml
+++ b/backend/config/corpora-api.yml
@@ -682,14 +682,11 @@ components:
             description: Gene specific information
             properties:
               gene_symbol:
-                type:
-                  string
+                type: string
               gene_description:
-                type:
-                  string
+                type: string
               additional_params:
-                type:
-                  object
+                type: object
 
   parameters:
     path_collection_uuid:

--- a/backend/config/corpora-api.yml
+++ b/backend/config/corpora-api.yml
@@ -221,26 +221,27 @@ paths:
         - cxguserCookie: []
       description: >-
         Add genesets to a private collection
-      operationId: corpora.lambdas.api.v1.collection_uuid.gene_sets.post
+      operationId: corpora.lambdas.api.v1.collection_uuid.gene_set.post
       parameters:
         - $ref: "#/components/parameters/path_collection_uuid"
-        - $ref: "#components/schema/gene_sets"
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                genesets:
+                  description: A list of genesets including their gene symbols and descriptions
+                  $ref: "#/components/schemas/gene_sets"
       responses:
         "200":
           description: OK
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  dataset_uuid:
-                    $ref: "#/components/schemas/dataset_uuid"
-                  presigned_url:
-                    type: string
-                  file_name:
-                    type: string
-                  file_size:
-                    type: number
+                type: array
+                items:
+                  $ref: "#/components/schemas/geneset"
         "401":
           $ref: "#/components/responses/401"
         "403":
@@ -667,6 +668,11 @@ components:
           type: string
         detail:
           type: string
+    gene_sets:
+      type: array
+      items:
+        type: array
+        items: { }
   parameters:
     path_collection_uuid:
       name: collection_uuid

--- a/backend/corpora/common/entities/geneset.py
+++ b/backend/corpora/common/entities/geneset.py
@@ -1,5 +1,5 @@
-from backend.corpora.common.corpora_orm import DbGeneset, DbGenesetDatasetLink
-from backend.corpora.common.entities.entity import Entity
+from ..corpora_orm import DbGeneset, DbGenesetDatasetLink
+from .entity import Entity
 
 
 class Geneset(Entity):

--- a/backend/corpora/common/entities/geneset.py
+++ b/backend/corpora/common/entities/geneset.py
@@ -20,9 +20,18 @@ class Geneset(Entity):
         genesets = session.query(cls.table).filter(cls.table.collection_id == collection_id).all()
         reshaped_genesets = []
         for geneset in genesets:
-            reshaped_genesets.append(geneset.to_dict(remove_attr=["gene_symbols", "created_at", "updated_at",
-                                                                  "collection", "collection_id",
-                                                                  "collection_visibility"]))
+            reshaped_genesets.append(
+                geneset.to_dict(
+                    remove_attr=[
+                        "gene_symbols",
+                        "created_at",
+                        "updated_at",
+                        "collection",
+                        "collection_id",
+                        "collection_visibility",
+                    ]
+                )
+            )
         return reshaped_genesets
 
 

--- a/backend/corpora/common/entities/geneset.py
+++ b/backend/corpora/common/entities/geneset.py
@@ -6,7 +6,7 @@ class Geneset(Entity):
     table = DbGeneset
 
     @classmethod
-    def create(cls, session, name: str, description: str, gene_symbols: object, dataset_ids: list = [], **kwargs):
+    def create(cls, session, name: str, description: str, gene_symbols: list, dataset_ids: list = [], **kwargs):
         gene_set = DbGeneset(name=name, description=description, gene_symbols=gene_symbols, **kwargs)
         session.add(gene_set)
         session.commit()

--- a/backend/corpora/common/entities/geneset.py
+++ b/backend/corpora/common/entities/geneset.py
@@ -6,7 +6,7 @@ class Geneset(Entity):
     table = DbGeneset
 
     @classmethod
-    def create(cls, session, name: str, description: str, gene_symbols: list, dataset_ids: list = [], **kwargs):
+    def create(cls, session, name: str, description: str, gene_symbols: object, dataset_ids: list = [], **kwargs):
         gene_set = DbGeneset(name=name, description=description, gene_symbols=gene_symbols, **kwargs)
         session.add(gene_set)
         session.commit()
@@ -18,7 +18,11 @@ class Geneset(Entity):
     @classmethod
     def retrieve_all_genesets_for_a_collection(cls, session, collection_id):
         genesets = session.query(cls.table).filter(cls.table.collection_id == collection_id).all()
-        return genesets
+        reshaped_genesets = []
+        for geneset in genesets:
+            reshaped_genesets.append(geneset.to_dict(remove_attr="gene_symbols"))
+        return reshaped_genesets
+
 
 
 class GenesetDatasetLink(Entity):

--- a/backend/corpora/common/entities/geneset.py
+++ b/backend/corpora/common/entities/geneset.py
@@ -20,9 +20,10 @@ class Geneset(Entity):
         genesets = session.query(cls.table).filter(cls.table.collection_id == collection_id).all()
         reshaped_genesets = []
         for geneset in genesets:
-            reshaped_genesets.append(geneset.to_dict(remove_attr="gene_symbols"))
+            reshaped_genesets.append(geneset.to_dict(remove_attr=["gene_symbols", "created_at", "updated_at",
+                                                                  "collection", "collection_id",
+                                                                  "collection_visibility"]))
         return reshaped_genesets
-
 
 
 class GenesetDatasetLink(Entity):

--- a/backend/corpora/lambdas/api/v1/collection_uuid/gene_set.py
+++ b/backend/corpora/lambdas/api/v1/collection_uuid/gene_set.py
@@ -16,8 +16,11 @@ def post(collection_uuid: str, body: dict, user: str):
     for gene_set in gene_sets:
         try:
             Geneset.create(
-                db_session, name=gene_set["gene_set_name"], description=gene_set["gene_set_description"],
-                gene_symbols=gene_set["genes"], collection=collection
+                db_session,
+                name=gene_set["gene_set_name"],
+                description=gene_set["gene_set_description"],
+                gene_symbols=gene_set["genes"],
+                collection=collection,
             )
         except IntegrityError:
             db_session.rollback()

--- a/backend/corpora/lambdas/api/v1/collection_uuid/gene_set.py
+++ b/backend/corpora/lambdas/api/v1/collection_uuid/gene_set.py
@@ -16,7 +16,8 @@ def post(collection_uuid: str, body: dict, user: str):
     for gene_set in gene_sets:
         try:
             Geneset.create(
-                db_session, name=gene_set[0], description=gene_set[1], gene_symbols=gene_set[2], collection=collection
+                db_session, name=gene_set["gene_set_name"], description=gene_set["gene_set_description"],
+                gene_symbols=gene_set["genes"], collection=collection
             )
         except IntegrityError:
             db_session.rollback()

--- a/backend/corpora/lambdas/api/v1/collection_uuid/gene_set.py
+++ b/backend/corpora/lambdas/api/v1/collection_uuid/gene_set.py
@@ -1,15 +1,15 @@
 from flask import make_response, g, jsonify
 from sqlalchemy.exc import IntegrityError
 
-from backend.corpora.common.corpora_orm import CollectionVisibility
-from backend.corpora.common.entities import Collection
-from backend.corpora.common.entities.geneset import Geneset
-from backend.corpora.common.utils.exceptions import ForbiddenHTTPException, InvalidParametersHTTPException
+from .....common.corpora_orm import CollectionVisibility
+from .....common.entities import Collection
+from .....common.entities.geneset import Geneset
+from .....common.utils.exceptions import ForbiddenHTTPException, InvalidParametersHTTPException
 
 
 def post(collection_uuid: str, body: dict, user: str):
     db_session = g.db_session
-    collection = Collection.if_owner(db_session, collection_uuid, CollectionVisibility.PRIVATE, user)
+    collection = Collection.if_owner(db_session, collection_uuid, CollectionVisibility.PRIVATE.name, user)
     if not collection:
         raise ForbiddenHTTPException
     gene_sets = body["gene_sets"]
@@ -20,7 +20,8 @@ def post(collection_uuid: str, body: dict, user: str):
                 name=gene_set["gene_set_name"],
                 description=gene_set["gene_set_description"],
                 gene_symbols=gene_set["genes"],
-                collection=collection,
+                collection_id=collection.id,
+                collection_visibility=collection.visibility.name
             )
         except IntegrityError:
             db_session.rollback()

--- a/backend/corpora/lambdas/api/v1/collection_uuid/gene_set.py
+++ b/backend/corpora/lambdas/api/v1/collection_uuid/gene_set.py
@@ -21,7 +21,7 @@ def post(collection_uuid: str, body: dict, user: str):
                 description=gene_set["gene_set_description"],
                 gene_symbols=gene_set["genes"],
                 collection_id=collection.id,
-                collection_visibility=collection.visibility.name
+                collection_visibility=collection.visibility.name,
             )
         except IntegrityError:
             db_session.rollback()

--- a/backend/corpora/lambdas/api/v1/collection_uuid/gene_set.py
+++ b/backend/corpora/lambdas/api/v1/collection_uuid/gene_set.py
@@ -15,8 +15,9 @@ def post(collection_uuid: str, body: dict, user: str):
     gene_sets = body["gene_sets"]
     for gene_set in gene_sets:
         try:
-            Geneset.create(db_session, name=gene_set[0], description=gene_set[1], gene_symbols=gene_set[2],
-                           collection=collection)
+            Geneset.create(
+                db_session, name=gene_set[0], description=gene_set[1], gene_symbols=gene_set[2], collection=collection
+            )
         except IntegrityError:
             db_session.rollback()
             raise InvalidParametersHTTPException("Duplicate geneset name")

--- a/backend/corpora/lambdas/api/v1/collection_uuid/gene_set.py
+++ b/backend/corpora/lambdas/api/v1/collection_uuid/gene_set.py
@@ -1,0 +1,20 @@
+from flask import make_response, g
+
+from backend.corpora.common.corpora_orm import CollectionVisibility
+from backend.corpora.common.entities import Collection
+from backend.corpora.common.entities.geneset import Geneset
+from backend.corpora.common.utils.exceptions import ForbiddenHTTPException
+
+
+def post(collection_uuid: str, body: dict, user: str):
+    db_session = g.db_sesson
+    collection = Collection.if_owner(db_session, collection_uuid, CollectionVisibility.PRIVATE, user)
+    if not collection:
+        raise ForbiddenHTTPException
+    gene_sets = body["gene_sets"]
+    for gene_set in gene_sets:
+        Geneset.create(db_session, name=gene_set[0], description=gene_set[1], gene_symbols=gene_set[2],
+                       collection=collection)
+
+    gene_sets = collection.genesets
+

--- a/backend/corpora/lambdas/api/v1/collection_uuid/gene_set.py
+++ b/backend/corpora/lambdas/api/v1/collection_uuid/gene_set.py
@@ -1,20 +1,25 @@
-from flask import make_response, g
+import sqlalchemy
+from flask import make_response, g, jsonify
 
 from backend.corpora.common.corpora_orm import CollectionVisibility
 from backend.corpora.common.entities import Collection
 from backend.corpora.common.entities.geneset import Geneset
-from backend.corpora.common.utils.exceptions import ForbiddenHTTPException
+from backend.corpora.common.utils.exceptions import ForbiddenHTTPException, InvalidParametersHTTPException
 
 
 def post(collection_uuid: str, body: dict, user: str):
-    db_session = g.db_sesson
+    db_session = g.db_session
     collection = Collection.if_owner(db_session, collection_uuid, CollectionVisibility.PRIVATE, user)
     if not collection:
         raise ForbiddenHTTPException
     gene_sets = body["gene_sets"]
     for gene_set in gene_sets:
-        Geneset.create(db_session, name=gene_set[0], description=gene_set[1], gene_symbols=gene_set[2],
-                       collection=collection)
+        try:
+            Geneset.create(db_session, name=gene_set[0], description=gene_set[1], gene_symbols=gene_set[2],
+                           collection=collection)
+        except sqlalchemy.exc.IntegrityError:
+            raise InvalidParametersHTTPException
 
-    gene_sets = collection.genesets
+    result = Geneset.retrieve_all_genesets_for_a_collection(db_session, collection_uuid)
 
+    return make_response(jsonify(result), 200)

--- a/backend/corpora/lambdas/api/v1/collection_uuid/gene_set.py
+++ b/backend/corpora/lambdas/api/v1/collection_uuid/gene_set.py
@@ -1,5 +1,5 @@
-import sqlalchemy
 from flask import make_response, g, jsonify
+from sqlalchemy.exc import IntegrityError
 
 from backend.corpora.common.corpora_orm import CollectionVisibility
 from backend.corpora.common.entities import Collection
@@ -17,8 +17,9 @@ def post(collection_uuid: str, body: dict, user: str):
         try:
             Geneset.create(db_session, name=gene_set[0], description=gene_set[1], gene_symbols=gene_set[2],
                            collection=collection)
-        except sqlalchemy.exc.IntegrityError:
-            raise InvalidParametersHTTPException
+        except IntegrityError:
+            db_session.rollback()
+            raise InvalidParametersHTTPException("Duplicate geneset name")
 
     result = Geneset.retrieve_all_genesets_for_a_collection(db_session, collection_uuid)
 

--- a/tests/unit/backend/chalice/api_server/collection_uuid/test_create_genesets.py
+++ b/tests/unit/backend/chalice/api_server/collection_uuid/test_create_genesets.py
@@ -17,17 +17,16 @@ class TestGenesetCreation(BaseAuthAPITest):
                 {
                     "gene_symbol": "gene1",
                     "gene_description": "describe a gene",
-                    "additional_params": {
-                        "randomProperty": "randomPropertyWords",
-                        "anotherProprerty": "moreWords"}
+                    "additional_params": {"randomProperty": "randomPropertyWords", "anotherProprerty": "moreWords"},
                 },
-                {"gene_symbol": "1", "gene_description": "words", "additional_params": {"a": "b", "c": "d"}}
-            ]
+                {"gene_symbol": "1", "gene_description": "words", "additional_params": {"a": "b", "c": "d"}},
+            ],
         }
         self.geneset2 = {
             "gene_set_name": "geneset2",
             "gene_set_description": "this is geneset 2",
-            "genes": [{"gene_symbol": "onegene"}]}
+            "genes": [{"gene_symbol": "onegene"}],
+        }
         self.geneset3 = {
             "gene_set_name": "geneset3",
             "gene_set_description": "this is geneset 3",
@@ -35,8 +34,8 @@ class TestGenesetCreation(BaseAuthAPITest):
                 {"gene_symbol": "1", "gene_description": "words", "additional_params": {"a": "b", "c": "d"}},
                 {"gene_symbol": "2", "gene_description": "words", "additional_params": {"a": "b", "c": "d"}},
                 {"gene_symbol": "3", "gene_description": "words", "additional_params": {"a": "b", "c": "d"}},
-                {"gene_symbol": "4", "gene_description": "words", "additional_params": {"a": "b", "c": "d"}}
-            ]
+                {"gene_symbol": "4", "gene_description": "words", "additional_params": {"a": "b", "c": "d"}},
+            ],
         }
         self.collection = self.generate_collection(
             self.session, visibility=CollectionVisibility.PRIVATE.name, owner="test_user_id"
@@ -63,19 +62,20 @@ class TestGenesetCreation(BaseAuthAPITest):
         body = json.loads(response.body)
         genesets = {}
         for x in body:
-            genesets[x['name']] = x['id']
+            genesets[x["name"]] = x["id"]
         geneset1 = Geneset.get(self.session, genesets["geneset1"])
         geneset2 = Geneset.get(self.session, genesets["geneset2"])
         geneset3 = Geneset.get(self.session, genesets["geneset3"])
 
-        self.assertEqual(geneset1.gene_symbols, self.geneset1['genes'])
-        self.assertEqual(geneset2.gene_symbols, self.geneset2['genes'])
-        self.assertEqual(geneset3.gene_symbols, self.geneset3['genes'])
+        self.assertEqual(geneset1.gene_symbols, self.geneset1["genes"])
+        self.assertEqual(geneset2.gene_symbols, self.geneset2["genes"])
+        self.assertEqual(geneset3.gene_symbols, self.geneset3["genes"])
 
     def test_geneset_creation__geneset_already_exists(self):
         data = {"gene_sets": [self.geneset1]}
-        Geneset.create(self.session, collection=self.collection, name="geneset1", description="words",
-                       gene_symbols=["aaa"])
+        Geneset.create(
+            self.session, collection=self.collection, name="geneset1", description="words", gene_symbols=["aaa"]
+        )
         response = self.app.post(self.test_url, headers=self.headers, data=json.dumps(data))
         self.assertEqual(400, response.status_code)
 

--- a/tests/unit/backend/chalice/api_server/collection_uuid/test_create_genesets.py
+++ b/tests/unit/backend/chalice/api_server/collection_uuid/test_create_genesets.py
@@ -47,7 +47,7 @@ class TestGenesetCreation(BaseAuthAPITest):
 
         Geneset.create(self.session, collection=collection, name="geneset1", description="words", gene_symbols=["aaa"])
         response = self.app.post(test_url, headers=headers, data=json.dumps(data))
-        self.assertEqual(500, response.status_code)
+        self.assertEqual(400, response.status_code)
 
     def test_geneset_creation__not_owner_403(self):
         data = {"gene_sets": [

--- a/tests/unit/backend/chalice/api_server/collection_uuid/test_create_genesets.py
+++ b/tests/unit/backend/chalice/api_server/collection_uuid/test_create_genesets.py
@@ -47,7 +47,6 @@ class TestGenesetCreation(BaseAuthAPITest):
         data = {"gene_sets": [self.geneset1, self.geneset2, self.geneset3]}
         response = self.app.post(self.test_url, headers=self.headers, data=json.dumps(data))
         response.raise_for_status()
-
         body = json.loads(response.body)
         self.assertEqual(len(body), 3)
         geneset_names = [x["name"] for x in body]

--- a/tests/unit/backend/chalice/api_server/collection_uuid/test_create_genesets.py
+++ b/tests/unit/backend/chalice/api_server/collection_uuid/test_create_genesets.py
@@ -1,0 +1,88 @@
+import json
+from backend.corpora.common.corpora_orm import CollectionVisibility, Base, generate_uuid
+from backend.corpora.common.entities.geneset import Geneset
+from tests.unit.backend.chalice.api_server.base_api_test import BaseAuthAPITest
+from tests.unit.backend.chalice.api_server.mock_auth import get_auth_token
+
+
+class TestGenesetCreation(BaseAuthAPITest):
+    # Note for now the validation is done on the frontend so we are only testing with clean data
+    # If we open up the api in the future we will need to validate and test for dirty data here as well
+
+
+
+    def test_geneset_creation__ok(self):
+        data = {"gene_sets": [
+            ["geneset1", "this is geneset 1",
+             ["gene1", "gene 1 description", {
+                 "randomProperty": "randomPropertyWords", "anotherProprerty": "moreWords"}],
+             ["gene2", "gene 2 description", {}],
+             ["gene3", "gene 3 description"],
+             ["gene4", "", {"randomProperty": "randomPropertyWords", "anotherProprerty": "moreWords"}],
+             ["gene5"]],
+            ["geneset2", "this is geneset2", ["onegene"]],
+            ["geneset3", "this is geneset3", ["1", "words", {"a": "b", "c": "d"}], ["2", "words", {"a": "b", "c": "d"}]]
+        ]}
+        collection = self.generate_collection(self.session, visibility=CollectionVisibility.PRIVATE.name, owner="test_user_id")
+        test_url = f"/dp/v1/collections/{collection.id}/genesets"
+        headers = {"host": "localhost", "Content-Type": "application/json", "Cookie": get_auth_token(self.app)}
+
+        response = self.app.post(test_url, headers=headers, data=json.dumps(data))
+        response.raise_for_status()
+
+        body = json.loads(response.body)
+        self.assertEqual(len(body), 3)
+        geneset_names = [x['name'] for x in body]
+        self.assertIn("geneset1", geneset_names)
+        self.assertIn("geneset2", geneset_names)
+        self.assertIn("geneset3", geneset_names)
+
+    def test_geneset_creation__geneset_already_exists(self):
+        data = {"gene_sets": [
+            ["geneset1", "this is geneset 1",
+             ["gene1", "gene 1 description"]]]}
+        collection = self.generate_collection(self.session, visibility=CollectionVisibility.PRIVATE.name, owner="test_user_id")
+        test_url = f"/dp/v1/collections/{collection.id}/genesets"
+        headers = {"host": "localhost", "Content-Type": "application/json", "Cookie": get_auth_token(self.app)}
+
+        Geneset.create(self.session, collection=collection, name="geneset1", description="words", gene_symbols=["aaa"])
+        response = self.app.post(test_url, headers=headers, data=json.dumps(data))
+        self.assertEqual(500, response.status_code)
+
+    def test_geneset_creation__not_owner_403(self):
+        data = {"gene_sets": [
+            ["geneset1", "this is geneset 1",
+             ["gene1", "gene 1 description"]]]}
+        collection = self.generate_collection(self.session, visibility=CollectionVisibility.PRIVATE.name,
+                                              owner="someone_else")
+        test_url = f"/dp/v1/collections/{collection.id}/genesets"
+        headers = {"host": "localhost", "Content-Type": "application/json", "Cookie": get_auth_token(self.app)}
+
+        response = self.app.post(test_url, headers=headers, data=json.dumps(data))
+        self.assertEqual(403, response.status_code)
+
+
+    def test_geneset_creation__not_private_403(self):
+        data = {"gene_sets": [
+            ["geneset1", "this is geneset 1",
+             ["gene1", "gene 1 description"]]]}
+        collection = self.generate_collection(self.session, visibility=CollectionVisibility.PUBLIC.name,
+                                              owner="test_user_id")
+        test_url = f"/dp/v1/collections/{collection.id}/genesets"
+        headers = {"host": "localhost", "Content-Type": "application/json", "Cookie": get_auth_token(self.app)}
+
+        response = self.app.post(test_url, headers=headers, data=json.dumps(data))
+        self.assertEqual(403, response.status_code)
+
+
+    def test_geneset_creation__no_collection_403(self):
+        uuid = generate_uuid()
+        data = {"gene_sets": [
+            ["geneset1", "this is geneset 1",
+             ["gene1", "gene 1 description"]]]}
+        test_url = f"/dp/v1/collections/{uuid}/genesets"
+        headers = {"host": "localhost", "Content-Type": "application/json", "Cookie": get_auth_token(self.app)}
+        response = self.app.post(test_url, headers=headers, data=json.dumps(data))
+        self.assertEqual(403, response.status_code)
+
+

--- a/tests/unit/backend/chalice/api_server/collection_uuid/test_create_genesets.py
+++ b/tests/unit/backend/chalice/api_server/collection_uuid/test_create_genesets.py
@@ -1,5 +1,5 @@
 import json
-from backend.corpora.common.corpora_orm import CollectionVisibility, Base, generate_uuid
+from backend.corpora.common.corpora_orm import CollectionVisibility, generate_uuid
 from backend.corpora.common.entities.geneset import Geneset
 from tests.unit.backend.chalice.api_server.base_api_test import BaseAuthAPITest
 from tests.unit.backend.chalice.api_server.mock_auth import get_auth_token
@@ -9,21 +9,34 @@ class TestGenesetCreation(BaseAuthAPITest):
     # Note for now the validation is done on the frontend so we are only testing with clean data
     # If we open up the api in the future we will need to validate and test for dirty data here as well
 
-
-
     def test_geneset_creation__ok(self):
-        data = {"gene_sets": [
-            ["geneset1", "this is geneset 1",
-             ["gene1", "gene 1 description", {
-                 "randomProperty": "randomPropertyWords", "anotherProprerty": "moreWords"}],
-             ["gene2", "gene 2 description", {}],
-             ["gene3", "gene 3 description"],
-             ["gene4", "", {"randomProperty": "randomPropertyWords", "anotherProprerty": "moreWords"}],
-             ["gene5"]],
-            ["geneset2", "this is geneset2", ["onegene"]],
-            ["geneset3", "this is geneset3", ["1", "words", {"a": "b", "c": "d"}], ["2", "words", {"a": "b", "c": "d"}]]
-        ]}
-        collection = self.generate_collection(self.session, visibility=CollectionVisibility.PRIVATE.name, owner="test_user_id")
+        data = {
+            "gene_sets": [
+                [
+                    "geneset1",
+                    "this is geneset 1",
+                    [
+                        "gene1",
+                        "gene 1 description",
+                        {"randomProperty": "randomPropertyWords", "anotherProprerty": "moreWords"},
+                    ],
+                    ["gene2", "gene 2 description", {}],
+                    ["gene3", "gene 3 description"],
+                    ["gene4", "", {"randomProperty": "randomPropertyWords", "anotherProprerty": "moreWords"}],
+                    ["gene5"],
+                ],
+                ["geneset2", "this is geneset2", ["onegene"]],
+                [
+                    "geneset3",
+                    "this is geneset3",
+                    ["1", "words", {"a": "b", "c": "d"}],
+                    ["2", "words", {"a": "b", "c": "d"}],
+                ],
+            ]
+        }
+        collection = self.generate_collection(
+            self.session, visibility=CollectionVisibility.PRIVATE.name, owner="test_user_id"
+        )
         test_url = f"/dp/v1/collections/{collection.id}/genesets"
         headers = {"host": "localhost", "Content-Type": "application/json", "Cookie": get_auth_token(self.app)}
 
@@ -32,16 +45,16 @@ class TestGenesetCreation(BaseAuthAPITest):
 
         body = json.loads(response.body)
         self.assertEqual(len(body), 3)
-        geneset_names = [x['name'] for x in body]
+        geneset_names = [x["name"] for x in body]
         self.assertIn("geneset1", geneset_names)
         self.assertIn("geneset2", geneset_names)
         self.assertIn("geneset3", geneset_names)
 
     def test_geneset_creation__geneset_already_exists(self):
-        data = {"gene_sets": [
-            ["geneset1", "this is geneset 1",
-             ["gene1", "gene 1 description"]]]}
-        collection = self.generate_collection(self.session, visibility=CollectionVisibility.PRIVATE.name, owner="test_user_id")
+        data = {"gene_sets": [["geneset1", "this is geneset 1", ["gene1", "gene 1 description"]]]}
+        collection = self.generate_collection(
+            self.session, visibility=CollectionVisibility.PRIVATE.name, owner="test_user_id"
+        )
         test_url = f"/dp/v1/collections/{collection.id}/genesets"
         headers = {"host": "localhost", "Content-Type": "application/json", "Cookie": get_auth_token(self.app)}
 
@@ -50,39 +63,31 @@ class TestGenesetCreation(BaseAuthAPITest):
         self.assertEqual(400, response.status_code)
 
     def test_geneset_creation__not_owner_403(self):
-        data = {"gene_sets": [
-            ["geneset1", "this is geneset 1",
-             ["gene1", "gene 1 description"]]]}
-        collection = self.generate_collection(self.session, visibility=CollectionVisibility.PRIVATE.name,
-                                              owner="someone_else")
+        data = {"gene_sets": [["geneset1", "this is geneset 1", ["gene1", "gene 1 description"]]]}
+        collection = self.generate_collection(
+            self.session, visibility=CollectionVisibility.PRIVATE.name, owner="someone_else"
+        )
         test_url = f"/dp/v1/collections/{collection.id}/genesets"
         headers = {"host": "localhost", "Content-Type": "application/json", "Cookie": get_auth_token(self.app)}
 
         response = self.app.post(test_url, headers=headers, data=json.dumps(data))
         self.assertEqual(403, response.status_code)
-
 
     def test_geneset_creation__not_private_403(self):
-        data = {"gene_sets": [
-            ["geneset1", "this is geneset 1",
-             ["gene1", "gene 1 description"]]]}
-        collection = self.generate_collection(self.session, visibility=CollectionVisibility.PUBLIC.name,
-                                              owner="test_user_id")
+        data = {"gene_sets": [["geneset1", "this is geneset 1", ["gene1", "gene 1 description"]]]}
+        collection = self.generate_collection(
+            self.session, visibility=CollectionVisibility.PUBLIC.name, owner="test_user_id"
+        )
         test_url = f"/dp/v1/collections/{collection.id}/genesets"
         headers = {"host": "localhost", "Content-Type": "application/json", "Cookie": get_auth_token(self.app)}
 
         response = self.app.post(test_url, headers=headers, data=json.dumps(data))
         self.assertEqual(403, response.status_code)
-
 
     def test_geneset_creation__no_collection_403(self):
         uuid = generate_uuid()
-        data = {"gene_sets": [
-            ["geneset1", "this is geneset 1",
-             ["gene1", "gene 1 description"]]]}
+        data = {"gene_sets": [["geneset1", "this is geneset 1", ["gene1", "gene 1 description"]]]}
         test_url = f"/dp/v1/collections/{uuid}/genesets"
         headers = {"host": "localhost", "Content-Type": "application/json", "Cookie": get_auth_token(self.app)}
         response = self.app.post(test_url, headers=headers, data=json.dumps(data))
         self.assertEqual(403, response.status_code)
-
-

--- a/tests/unit/backend/corpora/common/entities/test_genesets.py
+++ b/tests/unit/backend/corpora/common/entities/test_genesets.py
@@ -46,7 +46,7 @@ class TestGeneSets(DataPortalTestCase):
         geneset_2 = self.generate_geneset(self.session, collection=collection)
 
         genesets = Geneset.retrieve_all_genesets_for_a_collection(session=self.session, collection_id=collection.id)
-        linked_geneset_ids = [x['id'] for x in genesets]
+        linked_geneset_ids = [x["id"] for x in genesets]
         self.assertIn(geneset_0.id, linked_geneset_ids)
         self.assertIn(geneset_1.id, linked_geneset_ids)
         self.assertIn(geneset_2.id, linked_geneset_ids)

--- a/tests/unit/backend/corpora/common/entities/test_genesets.py
+++ b/tests/unit/backend/corpora/common/entities/test_genesets.py
@@ -46,7 +46,7 @@ class TestGeneSets(DataPortalTestCase):
         geneset_2 = self.generate_geneset(self.session, collection=collection)
 
         genesets = Geneset.retrieve_all_genesets_for_a_collection(session=self.session, collection_id=collection.id)
-        linked_geneset_ids = [x.id for x in genesets]
+        linked_geneset_ids = [x['id'] for x in genesets]
         self.assertIn(geneset_0.id, linked_geneset_ids)
         self.assertIn(geneset_1.id, linked_geneset_ids)
         self.assertIn(geneset_2.id, linked_geneset_ids)


### PR DESCRIPTION
#### Reviewers
**Functional:** 
- @Bento007 

**Readability:** 
- @seve 
---

## Changes
- add endpoint to allow for creation of genesets 

## Definition of Done (from ticket)
- The owner of a collection can use the endpoint to save a list of gene sets in the database
- The endpoint returns information about all of the gene sets associated with the collection (equivalent to what is returned by the get/collections/{collection_uuid} endpoint for gene sets)
- Fix for #910 
- 
## QA steps (optional)
