### PR TITLE
Wait for ECS upgrades to complete in CI

### DIFF
--- a/.happy/terraform/envs/prod/main.tf
+++ b/.happy/terraform/envs/prod/main.tf
@@ -13,4 +13,6 @@ module stack {
   frontend_url        = "https://production.single-cell.czi.technology"
   backend_url         = "https://api.production.single-cell.czi.technology"
   stack_prefix        = ""
+
+  wait_for_steady_state = var.wait_for_steady_state
 }

--- a/.happy/terraform/envs/prod/variables.tf
+++ b/.happy/terraform/envs/prod/variables.tf
@@ -34,3 +34,9 @@ variable happy_config_secret {
   type        = string
   description = "Happy Path configuration secret name"
 }
+
+variable wait_for_steady_state {
+  type        = bool
+  description = "Should terraform block until ECS reaches a steady state?"
+  default     = true
+}

--- a/.happy/terraform/envs/rdev/main.tf
+++ b/.happy/terraform/envs/rdev/main.tf
@@ -11,4 +11,6 @@ module stack {
   delete_protected    = false
   require_okta        = true
   stack_prefix        = "/${var.stack_name}"
+
+  wait_for_steady_state = var.wait_for_steady_state
 }

--- a/.happy/terraform/envs/rdev/variables.tf
+++ b/.happy/terraform/envs/rdev/variables.tf
@@ -34,3 +34,9 @@ variable happy_config_secret {
   type        = string
   description = "Happy Path configuration secret name"
 }
+
+variable wait_for_steady_state {
+  type        = bool
+  description = "Should terraform block until ECS reaches a steady state?"
+  default     = false
+}

--- a/.happy/terraform/envs/stage/main.tf
+++ b/.happy/terraform/envs/stage/main.tf
@@ -13,4 +13,6 @@ module stack {
   frontend_url        = "https://stage.single-cell.czi.technology"
   backend_url         = "https://api.stage.single-cell.czi.technology"
   stack_prefix        = ""
+
+  wait_for_steady_state = var.wait_for_steady_state
 }

--- a/.happy/terraform/envs/stage/variables.tf
+++ b/.happy/terraform/envs/stage/variables.tf
@@ -34,3 +34,9 @@ variable happy_config_secret {
   type        = string
   description = "Happy Path configuration secret name"
 }
+
+variable wait_for_steady_state {
+  type        = bool
+  description = "Should terraform block until ECS reaches a steady state?"
+  default     = true
+}

--- a/.happy/terraform/modules/ecs-stack/main.tf
+++ b/.happy/terraform/modules/ecs-stack/main.tf
@@ -168,6 +168,8 @@ module upload_error_lambda {
   artifact_bucket       = local.artifact_bucket
   cellxgene_bucket      = local.cellxgene_bucket
   lambda_execution_role = local.lambda_execution_role
+  subnets               = local.subnets
+  security_groups       = local.security_groups
 }
 
 module upload_sfn {

--- a/.happy/terraform/modules/ecs-stack/main.tf
+++ b/.happy/terraform/modules/ecs-stack/main.tf
@@ -158,7 +158,7 @@ module upload_batch {
   frontend_url      = local.frontend_url
 }
 
-module upload_lambda {
+module upload_error_lambda {
   source                = "../lambda"
   image                 = "${local.lambda_upload_repo}:${local.image_tag}"
   name                  = "uploadfailures"
@@ -176,6 +176,6 @@ module upload_sfn {
   job_queue_arn        = local.job_queue_arn
   role_arn             = local.sfn_role_arn
   custom_stack_name    = local.custom_stack_name
-  lambda_error_handler = module.upload_lambda.error_handler
+  lambda_error_handler = module.upload_error_lambda.arn
   deployment_stage     = local.deployment_stage
 }

--- a/.happy/terraform/modules/ecs-stack/main.tf
+++ b/.happy/terraform/modules/ecs-stack/main.tf
@@ -161,6 +161,7 @@ module upload_batch {
 module upload_lambda {
   source                = "../lambda"
   image                 = "${local.lambda_upload_repo}:${local.image_tag}"
+  name                  = "uploadfailures"
   custom_stack_name     = local.custom_stack_name
   remote_dev_prefix     = local.remote_dev_prefix
   deployment_stage      = local.deployment_stage

--- a/.happy/terraform/modules/ecs-stack/main.tf
+++ b/.happy/terraform/modules/ecs-stack/main.tf
@@ -14,6 +14,7 @@ locals {
   priority              = var.priority
   deployment_stage      = var.deployment_stage
   remote_dev_prefix     = var.stack_prefix
+  wait_for_steady_state = var.wait_for_steady_state
 
   migration_cmd         = ["make", "-C", "/corpora-data-portal/backend", "db/init_remote_dev"]
   deletion_cmd          = ["make", "-C", "/corpora-data-portal/backend", "db/delete_remote_dev"]
@@ -93,6 +94,8 @@ module frontend_service {
   api_url           = local.backend_url
   frontend_url      = local.frontend_url
   remote_dev_prefix = local.remote_dev_prefix
+
+  wait_for_steady_state = local.wait_for_steady_state
 }
 
 module backend_service {
@@ -116,6 +119,8 @@ module backend_service {
   api_url           = local.backend_url
   frontend_url      = local.frontend_url
   remote_dev_prefix = local.remote_dev_prefix
+
+  wait_for_steady_state = local.wait_for_steady_state
 }
 
 module migrate_db {

--- a/.happy/terraform/modules/ecs-stack/main.tf
+++ b/.happy/terraform/modules/ecs-stack/main.tf
@@ -43,7 +43,7 @@ locals {
   frontend_alb_dns      = try(local.secret[local.alb_key]["frontend"]["dns_name"], "")
   backend_alb_dns       = try(local.secret[local.alb_key]["backend"]["dns_name"], "")
 
-  artifact_bucket       = try(local.secret["s3_buckets"]["artifacts"]["name"], "")
+  artifact_bucket       = try(local.secret["s3_buckets"]["artifact"]["name"], "")
   cellxgene_bucket      = try(local.secret["s3_buckets"]["cellxgene"]["name"], "")
 
   ecs_role_arn          = local.secret["service_roles"]["ecs_role"]

--- a/.happy/terraform/modules/ecs-stack/variables.tf
+++ b/.happy/terraform/modules/ecs-stack/variables.tf
@@ -69,3 +69,9 @@ variable stack_prefix {
   description = "Do bucket storage paths and db schemas need to be prefixed with the stack name? (Usually '/{stack_name}' for dev stacks, and '' for staging/prod stacks)"
   default     = ""
 }
+
+variable wait_for_steady_state {
+  type        = bool
+  description = "Should terraform block until ECS services reach a steady state?"
+  default     = false
+}

--- a/.happy/terraform/modules/lambda/main.tf
+++ b/.happy/terraform/modules/lambda/main.tf
@@ -14,4 +14,8 @@ resource aws_lambda_function lambda_job_def {
       REMOTE_DEV_PREFIX = var.remote_dev_prefix
     }
   }
+  vpc_config {
+    subnet_ids         = var.subnets
+    security_group_ids = var.security_groups
+  }
 }

--- a/.happy/terraform/modules/lambda/main.tf
+++ b/.happy/terraform/modules/lambda/main.tf
@@ -2,9 +2,10 @@
 # 
 resource aws_lambda_function lambda_job_def {
   role          = var.lambda_execution_role
-  function_name = "dp-${var.deployment_stage}-${var.custom_stack_name}-lambda"
+  function_name = "dp-${var.deployment_stage}-${var.custom_stack_name}-${var.name}"
   package_type  = "Image"
   image_uri     = var.image
+  timeout       = 60
   environment {
     variables = {
       ARTIFACT_BUCKET = var.artifact_bucket,
@@ -13,9 +14,4 @@ resource aws_lambda_function lambda_job_def {
       REMOTE_DEV_PREFIX = var.remote_dev_prefix
     }
   }
-}
-
-resource aws_cloudwatch_log_group cloud_watch_logs_group {
-  retention_in_days = 365
-  name              = "/dp/${var.deployment_stage}/${var.custom_stack_name}/lambda-handler-error"
 }

--- a/.happy/terraform/modules/lambda/outputs.tf
+++ b/.happy/terraform/modules/lambda/outputs.tf
@@ -1,4 +1,4 @@
-output error_handler {
+output arn {
   value       = aws_lambda_function.lambda_job_def.arn
-  description = "ARN for the lambda error handler"
+  description = "ARN for this lambda"
 }

--- a/.happy/terraform/modules/lambda/variables.tf
+++ b/.happy/terraform/modules/lambda/variables.tf
@@ -38,3 +38,13 @@ variable lambda_execution_role {
   type        = string
   description = "Role for lambda execution"
 }
+
+variable security_groups {
+  type        = list(string)
+  description = "Security groups for lambda tasks"
+}
+
+variable subnets {
+  type        = list(string)
+  description = "Subnets for lambda tasks"
+}

--- a/.happy/terraform/modules/lambda/variables.tf
+++ b/.happy/terraform/modules/lambda/variables.tf
@@ -3,6 +3,11 @@ variable image {
   description = "Image name"
 }
 
+variable name {
+  type        = string
+  description = "Lambda name"
+}
+
 variable artifact_bucket {
   type        = string
   description = "Artifact bucket name"

--- a/.happy/terraform/modules/service/main.tf
+++ b/.happy/terraform/modules/service/main.tf
@@ -19,6 +19,8 @@ resource aws_ecs_service service {
     subnets          = var.subnets
     assign_public_ip = false
   }
+
+  wait_for_steady_state = var.wait_for_steady_state
 }
 
 resource aws_ecs_task_definition task_definition {

--- a/.happy/terraform/modules/service/variables.tf
+++ b/.happy/terraform/modules/service/variables.tf
@@ -103,3 +103,9 @@ variable priority {
   type        = number
   description = "Listener rule priority number within the given listener"
 }
+
+variable wait_for_steady_state {
+  type        = bool
+  description = "Whether Terraform should block until the service is in a steady state before exiting"
+  default     = false
+}


### PR DESCRIPTION
1. Fixes an s3 bucket naming mismatch
2. Makes sure error handler lambdas execute in our VPC network
2. Updates the prod & staging configuration so Terraform will [wait for ECS services to be healthy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecs_service#wait_for_steady_state) before exiting. This means that when we run integration tests after a deployment, we'll know that those tests are running against our upgraded services.
3. Support passing in valid CORS domains via env variables, even in production

#### Reviewers
**Functional:** 

**Readability:** 

---

## Changes
- add
- remove
- modify

## Definition of Done (from ticket)

## QA steps (optional)
