### PR TITLE
thuang-126-policy-change-logo-removal

### DIFF
--- a/frontend/src/components/common/staticPages/style.ts
+++ b/frontend/src/components/common/staticPages/style.ts
@@ -33,7 +33,6 @@ export const CZILogo = styled.img`
 
 export const CellxgeneLogo = styled.img`
   height: 35px;
-  margin-left: 10px;
 `;
 
 export const PrivacyStyle = styled.div`

--- a/frontend/src/pages/previewpolicies.tsx
+++ b/frontend/src/pages/previewpolicies.tsx
@@ -1,11 +1,9 @@
 import React, { FC } from "react";
 import { ROUTES } from "src/common/constants/routes";
 import rawCellxgeneLogo from "src/components/common/staticPages/cellxgene.png";
-import rawCZILogo from "src/components/common/staticPages/CZI_Logotype_RGB.png";
 import {
   CellxgeneLogo,
   CommonStyle,
-  CZILogo,
   Layout,
   PrivacyStyle,
 } from "src/components/common/staticPages/style";
@@ -18,11 +16,6 @@ const PreviewPolicies: FC = () => {
         <PrivacyStyle>
           <SEO title="Preview Policies" />
           <header>
-            <CZILogo
-              data-test-id="czi-logo"
-              src={String(rawCZILogo)}
-              alt="CZI logo"
-            />
             <CellxgeneLogo
               data-test-id="cellxgene-logo"
               src={String(rawCellxgeneLogo)}
@@ -64,11 +57,6 @@ const PreviewPolicies: FC = () => {
           <PrivacyStyle>
             {/* <SEO title="Privacy" /> */}
             {/* <header>
-              <CZILogo
-                data-test-id="czi-logo"
-                src={String(rawCZILogo)}
-                alt="CZI logo"
-              />
               <CellxgeneLogo
                 data-test-id="cellxgene-logo"
                 src={String(rawCellxgeneLogo)}
@@ -536,11 +524,6 @@ const PreviewPolicies: FC = () => {
           <PrivacyStyle>
             {/* <SEO title="Terms of Service" /> */}
             {/* <header>
-              <CZILogo
-                data-test-id="czi-logo"
-                src={String(rawCZILogo)}
-                alt="CZI logo"
-              />
               <CellxgeneLogo
                 data-test-id="cellxgene-logo"
                 src={String(rawCellxgeneLogo)}

--- a/frontend/src/pages/previewpolicies.tsx
+++ b/frontend/src/pages/previewpolicies.tsx
@@ -34,26 +34,24 @@ const PreviewPolicies: FC = () => {
             Summary of April 2021 Updates to Terms of Service and Privacy Policy
           </h1>
 
-          <p>
-            <span>
-              We periodically update our terms and policies to ensure that they
-              are transparent and easy to understand. Here is a summary of the
-              key updates from April 2021:
-              <ul>
-                <li>
-                  Cellxgene is now provided by the Chan Zuckerberg Initiative
-                  Foundation. The Chan Zuckerberg Initiative has moved its
-                  Science team to its 501(c)(3) private foundation from CZI,
-                  LLC. We’re committed to preserving the same experience for
-                  you. For questions about these changes, please contact us at{" "}
-                  <a href="mailto:privacy@chanzuckerberg.com">
-                    privacy@chanzuckerberg.com
-                  </a>
-                  .
-                </li>
-              </ul>
-            </span>
-          </p>
+          <span>
+            We periodically update our terms and policies to ensure that they
+            are transparent and easy to understand. Here is a summary of the key
+            updates from April 2021:
+            <ul>
+              <li>
+                Cellxgene is now provided by the Chan Zuckerberg Initiative
+                Foundation. The Chan Zuckerberg Initiative has moved its Science
+                team to its 501(c)(3) private foundation from CZI, LLC. We’re
+                committed to preserving the same experience for you. For
+                questions about these changes, please contact us at{" "}
+                <a href="mailto:privacy@chanzuckerberg.com">
+                  privacy@chanzuckerberg.com
+                </a>
+                .
+              </li>
+            </ul>
+          </span>
         </PrivacyStyle>
       </CommonStyle>
 
@@ -61,7 +59,7 @@ const PreviewPolicies: FC = () => {
         <CommonStyle>
           <PrivacyStyle>
             {/* <SEO title="Privacy" /> */}
-            <header>
+            {/* <header>
               <CZILogo
                 data-test-id="czi-logo"
                 src={String(rawCZILogo)}
@@ -72,7 +70,7 @@ const PreviewPolicies: FC = () => {
                 src={String(rawCellxgeneLogo)}
                 alt="cellxgene logo"
               />
-            </header>
+            </header> */}
 
             <br />
             <h3>
@@ -486,7 +484,7 @@ const PreviewPolicies: FC = () => {
                         privacy@chanzuckerberg.com
                       </a>
                       .
-                      <p>
+                      <div>
                         To comply with article 27 of the GDPR and the UK-GDPR,
                         we have appointed a representative who can accept
                         communications on behalf of CZIF and CZI LLC in relation
@@ -519,7 +517,7 @@ const PreviewPolicies: FC = () => {
                             UKrepresentative.ChanZuckerberg@twobirds.com
                           </a>
                         </address>
-                      </p>
+                      </div>
                     </li>
                   </ol>
                 </li>
@@ -533,7 +531,7 @@ const PreviewPolicies: FC = () => {
         <CommonStyle>
           <PrivacyStyle>
             {/* <SEO title="Terms of Service" /> */}
-            <header>
+            {/* <header>
               <CZILogo
                 data-test-id="czi-logo"
                 src={String(rawCZILogo)}
@@ -544,7 +542,7 @@ const PreviewPolicies: FC = () => {
                 src={String(rawCellxgeneLogo)}
                 alt="cellxgene logo"
               />
-            </header>
+            </header> */}
 
             <h1 id="tos">Terms of Use</h1>
 

--- a/frontend/src/pages/previewpolicies.tsx
+++ b/frontend/src/pages/previewpolicies.tsx
@@ -30,11 +30,15 @@ const PreviewPolicies: FC = () => {
             />
           </header>
 
+          <br />
+
           <h1>
             Summary of April 2021 Updates to Terms of Service and Privacy Policy
           </h1>
 
-          <span>
+          <br />
+
+          <div>
             We periodically update our terms and policies to ensure that they
             are transparent and easy to understand. Here is a summary of the key
             updates from April 2021:
@@ -51,7 +55,7 @@ const PreviewPolicies: FC = () => {
                 .
               </li>
             </ul>
-          </span>
+          </div>
         </PrivacyStyle>
       </CommonStyle>
 


### PR DESCRIPTION
#### Reviewers
**Functional:** 

**Readability:** 

---

## Changes
- add
- remove unneeded logos!
- modify

<img width="761" alt="Screen Shot 2021-03-17 at 5 24 31 PM" src="https://user-images.githubusercontent.com/6309723/111555480-bd19a600-8745-11eb-806c-9de3e41f1b8b.png">

AND:

<img width="938" alt="Screen Shot 2021-03-17 at 5 18 34 PM" src="https://user-images.githubusercontent.com/6309723/111555096-e2f27b00-8744-11eb-8d2d-68596194bb95.png">


## Definition of Done (from ticket)

## QA steps (optional)
