### PR TITLE
thuang-959-hide-contact-when-unavailable

### DIFF
--- a/frontend/src/views/Collection/utils.tsx
+++ b/frontend/src/views/Collection/utils.tsx
@@ -31,14 +31,16 @@ export function renderLinks(links: Link[]) {
 }
 
 export function renderContact(
-  contact_name: Collection["contact_name"],
-  contact_email: Collection["contact_email"]
+  contact_name?: Collection["contact_name"],
+  contact_email?: Collection["contact_email"]
 ) {
+  if (!contact_name || !contact_email) return null;
+
   return (
-    <React.Fragment>
+    <>
       <span className={Classes.TEXT_MUTED}>Contact</span>
       <StyledLink href={"mailto:" + contact_email}>{contact_name}</StyledLink>
-    </React.Fragment>
+    </>
   );
 }
 


### PR DESCRIPTION
#### Reviewers
**Functional:** 
@Bento007 

**Readability:** 
@MDunitz 

---

## Changes
- add
- remove
- modify
Hide contact field when unavailable

BEFORE:

<img width="917" alt="Screen Shot 2021-03-18 at 2 47 55 PM" src="https://user-images.githubusercontent.com/6309723/111702191-20b0db80-87f9-11eb-8748-0375df0e08a0.png">

AFTER:

<img width="845" alt="Screen Shot 2021-03-18 at 2 48 10 PM" src="https://user-images.githubusercontent.com/6309723/111702193-227a9f00-87f9-11eb-8d26-f87bcf775be5.png">


## Definition of Done (from ticket)

## QA steps (optional)
1. Pull branch
2. `npm i && npm start`
3. Visit: `http://localhost:8000/collections/18e6337b-8c36-4977-9ac8-ca8aa5494481`
4. You should not see an empty Contact field anymore!