### PR TITLE
Set stage urls to be live staging

### DIFF
--- a/.happy/terraform/envs/stage/main.tf
+++ b/.happy/terraform/envs/stage/main.tf
@@ -10,8 +10,8 @@ module stack {
   deployment_stage    = "staging"
   delete_protected    = true
   require_okta        = false
-  frontend_url        = "https://stage.single-cell.czi.technology"
-  backend_url         = "https://api.stage.single-cell.czi.technology"
+  frontend_url        = "https://cellxgene.staging.single-cell.czi.technology"
+  backend_url         = "https://api.cellxgene.staging.single-cell.czi.technology"
   stack_prefix        = ""
 
   wait_for_steady_state = var.wait_for_steady_state


### PR DESCRIPTION
Flipping URLs to use the staging URLs that are set up in single-cell-infra, instead of the URLs used internally by happy path.