### PR TITLE
Unify DNS for local dev

### DIFF
--- a/DEV_ENV.md
+++ b/DEV_ENV.md
@@ -4,7 +4,7 @@
 1. [install docker](https://docs.docker.com/get-docker/). If brew is installed run `brew install docker`.
 1. [install chamber](https://github.com/segmentio/chamber). If brew is installed run `brew install chamber`. (This is needed for running functional tests.)
 1. From the root of this repository, run `make local-init` to build and run the dev environment. The first build takes awhile, but subsequent runs will use cached artifacts.
-1. Visit [http://localhost:5000](http://localhost:5000) to view the backend, and [http://localhost:8000](http://localhost:8000) for the frontend.
+1. Visit [http://backend.corporanet.local:5000](http://backend.corporanet.local:5000) to view the backend, and [http://frontend.corporanet.local:8000](http://frontend:8000) for the frontend.
 1. `make local-dbconsole` starts a connection with the local postgresql db.
 1. **Open the source code and start editing!**
   - Modify code in the `frontend/src` directory, save your changes and the browser will update in real time.

--- a/Makefile
+++ b/Makefile
@@ -155,15 +155,15 @@ local-shell: ## Open a command shell in one of the dev containers. ex: make loca
 local-unit-test: ## Run backend tests in the dev environment
 	@if [ -z "$(path)" ]; then \
         echo "Running all tests"; \
-		docker-compose exec -T backend bash -c "cd /corpora-data-portal && make container-unittest"; \
+		docker-compose exec -e DEV_MODE_COOKIES= -T backend bash -c "cd /corpora-data-portal && make container-unittest"; \
 	else \
 		echo "Running test(s): $(path)"; \
-		docker-compose exec -T backend bash -c "cd /corpora-data-portal && python -m unittest $(path)"; \
+		docker-compose exec -e DEV_MODE_COOKIES= -T backend bash -c "cd /corpora-data-portal && python -m unittest $(path)"; \
 	fi
 	if [ ! -z "$(CODECOV_TOKEN)" ]; then \
 		ci_env=$$(bash <(curl -s https://codecov.io/env)); \
 		docker-compose exec -T backend bash -c "apt-get update && apt-get install -y git"; \
-		docker-compose exec -e CI=true $$ci_env -T backend bash -c "cd /corpora-data-portal && bash <(curl -s https://codecov.io/bash) -cF backend,python,unitTest"; \
+		docker-compose exec -e DEV_MODE_COOKIES= -e CI=true $$ci_env -T backend bash -c "cd /corpora-data-portal && bash <(curl -s https://codecov.io/bash) -cF backend,python,unitTest"; \
 	fi
 
 # We optionally pass BOTO_ENDPOINT_URL if it is set, even if it is

--- a/Makefile
+++ b/Makefile
@@ -140,6 +140,8 @@ local-clean: local-nohostconfig ## Remove everything related to the local dev en
 	docker-compose rm -sf
 	-docker volume rm corpora-data-portal_database
 	-docker volume rm corpora-data-portal_localstack
+	-docker network rm corpora-data-portal_corporanet
+	-docker network rm corpora-data-portal_default
 
 .PHONY: local-logs
 local-logs: ## Tail the logs of the dev env containers. ex: make local-logs CONTAINER=backend

--- a/backend/chalice/api_server/app.py
+++ b/backend/chalice/api_server/app.py
@@ -40,7 +40,7 @@ def get_chalice_app(flask_app):
     deployment = os.environ["DEPLOYMENT_STAGE"]
     allowed_origins = []
     if deployment not in ["prod"]:
-        allowed_origins.extend(["http://.*\.corporanet\.local:\d+", "^http://localhost:\d+"])
+        allowed_origins.extend([r"http://.*\.corporanet\.local:\d+", r"^http://localhost:\d+"])
     if os.getenv("FRONTEND_URL"):
         allowed_origins.append(os.getenv("FRONTEND_URL"))
     if deployment != "test":  # pragma: no cover

--- a/backend/chalice/api_server/app.py
+++ b/backend/chalice/api_server/app.py
@@ -40,7 +40,7 @@ def get_chalice_app(flask_app):
     deployment = os.environ["DEPLOYMENT_STAGE"]
     allowed_origins = []
     if deployment not in ["prod"]:
-        allowed_origins.append(r"^http://localhost:\d+")
+        allowed_origins.extend(["http://.*\.corporanet\.local:\d+", "^http://localhost:\d+"])
     if os.getenv("FRONTEND_URL"):
         allowed_origins.append(os.getenv("FRONTEND_URL"))
     if deployment != "test":  # pragma: no cover
@@ -58,9 +58,12 @@ def get_chalice_app(flask_app):
     app.log.info(f"CORS allowed_origins: {allowed_origins}")
 
     # FIXME, enforce that the flask_secret_key is found once all secrets are setup for all environments
+    require_secure_cookies = True
+    if os.getenv("DEV_MODE_COOKIES"):
+        require_secure_cookies = False
     flask_app.config.update(
         SECRET_KEY=flask_secret_key,
-        SESSION_COOKIE_SECURE=True,
+        SESSION_COOKIE_SECURE=require_secure_cookies,
         SESSION_COOKIE_HTTPONLY=True,
         SESSION_COOKIE_SAMESITE="Lax",
     )

--- a/backend/config/database.ini
+++ b/backend/config/database.ini
@@ -2,7 +2,7 @@
 
 [alembic]
 # path to migration scripts
-script_location = database
+script_location = database.corporadev.local
 
 # template used to generate migration files
 # file_template = %%(rev)s_%%(slug)s

--- a/backend/corpora/lambdas/api/v1/authentication.py
+++ b/backend/corpora/lambdas/api/v1/authentication.py
@@ -112,8 +112,11 @@ def save_token(cookie_name: str, token: dict) -> None:
     @after_this_request
     def _save_cookie(response):
         value = base64.b64encode(json.dumps(dict(token)).encode("utf-8"))
+        require_secure_cookies = True
+        if os.getenv("DEV_MODE_COOKIES"):
+            require_secure_cookies = False
         response.set_cookie(
-            cookie_name, value, httponly=True, secure=True, samesite="Strict", max_age=24 * 60 * 60 * 90
+            cookie_name, value, httponly=True, secure=require_secure_cookies, samesite="Strict", max_age=24 * 60 * 60 * 90
         )
         return response
 

--- a/backend/corpora/lambdas/api/v1/authentication.py
+++ b/backend/corpora/lambdas/api/v1/authentication.py
@@ -116,7 +116,12 @@ def save_token(cookie_name: str, token: dict) -> None:
         if os.getenv("DEV_MODE_COOKIES"):
             require_secure_cookies = False
         response.set_cookie(
-            cookie_name, value, httponly=True, secure=require_secure_cookies, samesite="Strict", max_age=24 * 60 * 60 * 90
+            cookie_name,
+            value,
+            httponly=True,
+            secure=require_secure_cookies,
+            samesite="Strict",
+            max_age=24 * 60 * 60 * 90,
         )
         return response
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,10 @@ services:
     volumes:
       - database:/var/lib/postgresql/data
       - ./backend/database:/import
+    networks:
+       corporanet:
+          aliases:
+            - database.corporanet.local
   localstack:
     image: localstack/localstack@sha256:7c6635493185d25165979995fb073fd789c72b6d8b17ef3a70b798d55576732f
     ports:
@@ -25,6 +29,10 @@ services:
       - DEFAULT_REGION=us-west-2
     volumes:
       - localstack:/tmp/localstack
+    networks:
+       corporanet:
+          aliases:
+            - localstack.corporanet.local
   frontend:
     image: "${DOCKER_REPO}corpora-frontend"
     build:
@@ -44,6 +52,10 @@ services:
     volumes:
       - ./frontend:/corpora-frontend
       - /corpora-frontend/node_modules/
+    networks:
+       corporanet:
+          aliases:
+            - frontend.corporanet.local
   upload_failures:
     image: "${DOCKER_REPO}corpora-upload-failures"
     build:
@@ -72,6 +84,10 @@ services:
       - DEPLOYMENT_STAGE=dev
       - ARTIFACT_BUCKET=artifact-bucket
       - CELLXGENE_BUCKET=cellxgene-bucket
+    networks:
+       corporanet:
+          aliases:
+            - uploadfailures.corporanet.local
   processing:
     image: "${DOCKER_REPO}corpora-upload"
     build:
@@ -97,6 +113,10 @@ services:
       - DEPLOYMENT_STAGE=dev
       - ARTIFACT_BUCKET=artifact-bucket
       - CELLXGENE_BUCKET=cellxgene-bucket
+    networks:
+       corporanet:
+          aliases:
+            - processing.corporanet.local
   backend:
     image: "${DOCKER_REPO}corpora-backend"
     build:
@@ -121,6 +141,7 @@ services:
       - BOTO_ENDPOINT_URL=http://localstack:4566
       - DEPLOYMENT_STAGE=dev
       - RESTART_ON_FAILURE=yes
+      - DEV_MODE_COOKIES=1
       - IS_DOCKER_DEV=yes # This skips some unit tests.
     command: ["python3", "/chalice/run_local_server.py", "--host", "0.0.0.0"]
     volumes:
@@ -135,6 +156,10 @@ services:
       - ./backend/chalice/api_server/.chalice-dev:/corpora-data-portal/backend/chalice/api_server/.chalice
       - ./backend/corpora:/corpora-data-portal/backend/chalice/api_server/chalicelib/corpora
       - ./backend/config:/corpora-data-portal/backend/chalice/api_server/chalicelib/config
+    networks:
+       corporanet:
+          aliases:
+            - backend.corporanet.local
   oidc:
     image: soluto/oidc-server-mock:0.3.0
     ports:
@@ -159,6 +184,12 @@ services:
     volumes:
       - ./oauth/pkcs12:/tmp/pkcs12:ro
       - ./oauth:/tmp/config:ro
+    networks:
+       corporanet:
+          aliases:
+            - oidc.corporanet.local
+networks:
+  corporanet:
 volumes:
   database:
   localstack:

--- a/frontend/Makefile
+++ b/frontend/Makefile
@@ -52,8 +52,6 @@ e2e:
 
 .PHONY: smoke-test-with-local-dev
 smoke-test-with-local-dev:
-	# HACK/TODO - Temporarily reroute backend requests to docker-compose backend DNS name.
-	cp src/configs/local-docker.js src/configs/configs.js
 	npm run e2e; \
 	test_result=$$?; \
 	cp src/configs/local.js src/configs/configs.js; \

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -110,7 +110,7 @@ This starts an FE server that hits a **local** API server
 1. Requirements:
 
    1. You are able to spin up a local BE server
-   1. Your `src/configs/configs.js` points to local BE server. E.g., `http://localhost:5000`
+   1. Your `src/configs/configs.js` points to local BE server. E.g., `http://backend.corporanet.local:5000`
 
 1. For Gatsby Prod Build: `npm run smoke-test-with-local-backend`
 

--- a/frontend/src/configs/local.js
+++ b/frontend/src/configs/local.js
@@ -2,7 +2,7 @@
 // to a new file named `configs.js` in this directory.
 
 const configs = {
-  API_URL: "http://localhost:5000",
+  API_URL: "http://backend.corporanet.local:5000",
 };
 
 if (typeof module !== "undefined") module.exports = configs;

--- a/oauth/clients-config.json
+++ b/oauth/clients-config.json
@@ -8,8 +8,8 @@
             "authorization_code"
         ],
         "RedirectUris": [
-            "https://localhost:5000/dp/v1/oauth2/callback",
-            "http://localhost:5000/dp/v1/oauth2/callback"
+            "https://backend.corporanet.local:5000/dp/v1/oauth2/callback",
+            "http://backend.corporanet.local:5000/dp/v1/oauth2/callback"
         ],
         "AllowedScopes": [
            "openid", "profile", "email", "offline_access"

--- a/oauth/pkcs12/generate_cert.sh
+++ b/oauth/pkcs12/generate_cert.sh
@@ -1,9 +1,9 @@
 if [ ! -f server.crt ]; then
-  openssl req -x509 -newkey rsa:4096 -sha256 -days 3560 -nodes -keyout server.key -out server.crt -subj '/CN=localhost' -extensions san -nodes -config <( \
+  openssl req -x509 -newkey rsa:4096 -sha256 -days 3560 -nodes -keyout server.key -out server.crt -subj '/CN=oidc.corporanet.local' -extensions san -nodes -config <( \
     echo '[req]'; \
     echo 'distinguished_name=req'; \
     echo '[san]'; \
-    echo 'subjectAltName=DNS:localhost')
+    echo 'subjectAltName=DNS:oidc')
 else
     echo "Cert already exists, skipping"
 fi

--- a/scripts/happy
+++ b/scripts/happy
@@ -1167,8 +1167,14 @@ class HostnameManager():
         containers = []
         with open("docker-compose.yml") as composefile:
             result = yaml.load(composefile, Loader=yaml.Loader)
+            got_alias = False
             for service_name, service in result["services"].items():
-                containers.append(service_name)
+                for networkname, netconf in service.get("networks", {}).items():
+                    for alias in netconf.get("aliases", []):
+                        got_alias = True
+                        containers.append(alias)
+                if not got_alias:
+                    containers.append(service_name)
         return containers
 
     def cleanup_config(self, borders, config):

--- a/scripts/happy
+++ b/scripts/happy
@@ -1142,6 +1142,93 @@ def watch(ctx, stack_name):
     stack.watch()
     stack.print_outputs()
 
+@cli.group()
+def hosts():
+    "Commands to manage system hostsfile"
+    pass
+
+class HostnameManager():
+    def __init__(self, filename):
+        self.filename = filename
+
+    def get_file_borders(self):
+        cwd = os.getcwd()
+        directory = os.path.split(cwd)[-1]
+        return [
+            f"# ==== Happy docker-compose DNS for {directory} ===\n",
+            f"# ==== Happy docker-compose DNS for {directory} ===\n",
+        ]
+
+    def get_hostsfile(self):
+        with open(self.filename, "r") as hostsfile:
+            return hostsfile.readlines()
+
+    def get_compose_containers(self):
+        containers = []
+        with open("docker-compose.yml") as composefile:
+            result = yaml.load(composefile, Loader=yaml.Loader)
+            for service_name, service in result["services"].items():
+                containers.append(service_name)
+        return containers
+
+    def cleanup_config(self, borders, config):
+        write_lines = True
+        new_config = []
+        for idx in range(len(config)):
+            line = config[idx]
+            if write_lines and line == borders[0]:
+                write_lines = False
+                continue
+            if not write_lines and line == borders[1]:
+                write_lines = True
+                continue
+            if write_lines:
+                new_config.append(line)
+        return new_config
+
+    def update_config(self, config, newconfig):
+        with open(self.filename, "w") as hostfile:
+            for line in config:
+                hostfile.write(line)
+            for line in newconfig:
+                hostfile.write(line)
+
+    def generate_config(self, borders, containers):
+        lines = []
+        lines.append(borders[0])
+        for container in containers:
+            lines.append(f"127.0.0.1\t{container}\n")
+        lines.append(borders[1])
+        return lines
+
+@hosts.command()
+@click.option(
+    "--hostsfile",
+    default="/etc/hosts",
+    help="Path to system hosts file"
+)
+def install(hostsfile):
+    "Install compose DNS entries"
+    hostmgr = HostnameManager(hostsfile)
+    config = hostmgr.get_hostsfile()
+    containers = hostmgr.get_compose_containers()
+    borders = hostmgr.get_file_borders()
+    config = hostmgr.cleanup_config(borders, config)
+    hostmgr.update_config(config, hostmgr.generate_config(borders, containers))
+
+@hosts.command()
+@click.option(
+    "--hostsfile",
+    default="/etc/hosts",
+    help="Path to system hosts file"
+)
+def uninstall(hostsfile):
+    "Remove compose DNS entries"
+    hostmgr = HostnameManager(hostsfile)
+    config = hostmgr.get_hostsfile()
+    borders = hostmgr.get_file_borders()
+    config = hostmgr.cleanup_config(borders, config)
+    hostmgr.update_config(config, [])
 
 if __name__ == "__main__":
     obj = {}

--- a/scripts/login.py
+++ b/scripts/login.py
@@ -8,7 +8,7 @@ def get_cxguser_cookie():
     # suppress https warnings.
     requests.packages.urllib3.disable_warnings(requests.packages.urllib3.exceptions.InsecureRequestWarning)
 
-    OIDC_LOGIN_URL = "http://localhost:5000/dp/v1/login"
+    OIDC_LOGIN_URL = "http://backend.corporanet.local:5000/dp/v1/login"
     USERS_CONFIGURATION_PATH = "oauth/users.json"
     CLIENTS_CONFIGURATION_PATH = "oauth/clients-config.json"
 
@@ -24,7 +24,7 @@ def get_cxguser_cookie():
     client_data = data[0]
     client_id = client_data["ClientId"]
 
-    # Calling http://localhost:5000/dp/v1/login
+    # Calling http://backend.corporanet.local:5000/dp/v1/login
     session = requests.session()
     response = session.get(OIDC_LOGIN_URL, verify=False, allow_redirects=False)
     location = response.headers["Location"]

--- a/scripts/setup_dev_data.sh
+++ b/scripts/setup_dev_data.sh
@@ -4,17 +4,17 @@ export AWS_DEFAULT_REGION=us-west-2
 export AWS_ACCESS_KEY_ID=nonce
 export AWS_SECRET_ACCESS_KEY=nonce
 
-export FRONTEND_URL=http://localhost:8000
-export BACKEND_URL=http://localhost:5000
+export FRONTEND_URL=http://frontend.corporanet.local:8000
+export BACKEND_URL=http://backend.corporanet.local:5000
 
 # NOTE: This script is intended to run INSIDE the dockerized dev environment!
 # If you need to run it directly on your laptop for some reason, change
 # localstack below to localhost
-export LOCALSTACK_URL=http://localstack:4566
+export LOCALSTACK_URL=http://localstack.corporanet.local:4566
 # How the backend can reach the OIDC idp
-export OIDC_INTERNAL_URL=http://oidc
+export OIDC_INTERNAL_URL=http://oidc.corporanet.local
 # How a web browser can reach the OIDC idp
-export OIDC_BROWSER_URL=https://localhost:8443
+export OIDC_BROWSER_URL=https://oidc.corporanet.local:8443
 
 echo -n "waiting for localstack to be ready: "
 until $(curl --output /dev/null --silent --head ${LOCALSTACK_URL}); do

--- a/scripts/setup_dev_data.sh
+++ b/scripts/setup_dev_data.sh
@@ -63,9 +63,9 @@ ${local_aws} secretsmanager update-secret --secret-id corpora/cicd/test/auth0-se
     "grant_type": ""
 }' || true
 
-${local_aws} secretsmanager update-secret --secret-id corpora/backend/dev/database_local --secret-string '{"database_uri": "postgresql://corpora:test_pw@database:5432"}' || true
+${local_aws} secretsmanager update-secret --secret-id corpora/backend/dev/database_local --secret-string '{"database_uri": "postgresql://corpora:test_pw@database.corporanet.local:5432"}' || true
 ${local_aws} secretsmanager update-secret --secret-id corpora/backend/dev/config --secret-string '{"upload_sfn_arn": "arn:aws:states:us-west-2:000000000000:stateMachine:uploader-dev-sfn"}' || true
-${local_aws} secretsmanager update-secret --secret-id corpora/backend/test/database_local --secret-string '{"database_uri": "postgresql://corpora:test_pw@database:5432"}' || true
+${local_aws} secretsmanager update-secret --secret-id corpora/backend/test/database_local --secret-string '{"database_uri": "postgresql://corpora:test_pw@database.corporanet.local:5432"}' || true
 ${local_aws} secretsmanager update-secret --secret-id corpora/backend/test/config --secret-string '{"upload_sfn_arn": "aws::::/upload"}'
 
 # Make a 1mb data file


### PR DESCRIPTION
** Experimental! **

This is a draft PR to get some feedback from the team about usability.

We've been having some trouble getting playwright to work properly when run against local dev due to some inconsistencies in the way DNS works inside a docker network, and on our laptops.

When containers connect to each other, they use service names defined in docker-compose.yml (for example, "backend", and "database"), but when we connect to the containers from our laptops, we use the 'localhost' name with different ports for each container. This means that OAuth redirects inside the docker network need to be different than redirects for browsers running on our laptops.

This PR makes the container names consistent inside and outside of the docker network by adding /etc/hosts entries to our systems to create aliases for {service_name}.corporanet.local, and using docker network aliases inside the docker network with the same name. 

After pulling this branch down, engineers will need to re-run `make local-init` to apply all the necessary changes to their environment.

The `corporanet.local` suffix allows us to use a Samesite=Lax policy for the session cookie. Without domain suffixes, browsers don't allow sending cookies to the backend on redirects.

#### Reviewers
**Functional:** 

**Readability:** 

---

## Changes
- add
- remove
- modify

## Definition of Done (from ticket)

## QA steps (optional)
