### PR TITLE
thuang-update-localStorage-boolean-values

### DIFF
--- a/frontend/jest/featureFlags.js
+++ b/frontend/jest/featureFlags.js
@@ -5,8 +5,8 @@ module.exports = {
   origins: [
     {
       localStorage: [
-        { name: "cxg-ff-auth", value: "true" },
-        { name: "cxg-ff-cc", value: "true" },
+        { name: "cxg-ff-auth", value: "yes" },
+        { name: "cxg-ff-cc", value: "yes" },
       ],
       origin: TEST_URL,
     },

--- a/frontend/src/common/localStorage/set.ts
+++ b/frontend/src/common/localStorage/set.ts
@@ -1,6 +1,6 @@
 export enum BOOLEAN {
-  TRUE = "true",
-  FALSE = "false",
+  TRUE = "yes",
+  FALSE = "no",
 }
 
 export function set(key: string, value: BOOLEAN) {


### PR DESCRIPTION
#### Reviewers
**Functional:** 

**Readability:** 

---

## Changes
- add
- remove
- modify
- `localStorage` values are changed from "`true"` and "`false"` to `"yes"` and `"no"` to match Explorer's convention

Note that feature flags will use `"yes"` and `"no"` from now on too, so please add the relevant feature flags in the URL params to overwrite the values again! E.g., `?auth=true&cc=true` (this part stays the same)

## Definition of Done (from ticket)

<img width="811" alt="Screen Shot 2021-03-24 at 11 40 38 AM" src="https://user-images.githubusercontent.com/6309723/112366318-e54d5b80-8c95-11eb-8c89-c11a0fc171f6.png">

## QA steps (optional)
1. Clear your localStorage for the site and try setting feature flags and cookie banner again!