### PR TITLE
thuang-fix-next-js

### DIFF
--- a/frontend/src/components/Collections/components/Grid/components/Row/CollectionRow/index.tsx
+++ b/frontend/src/components/Collections/components/Grid/components/Row/CollectionRow/index.tsx
@@ -82,9 +82,10 @@ const CollectionRow: FC<Props> = (props) => {
     <StyledRow>
       <StyledCell>
         <Link href={`/collections/${id}${isPrivate ? "/private" : ""}`}>
-          {/* TODO(thuang): Remove the disable once the issue resolves: https://github.com/vercel/next.js/discussions/8207 */}
-          {/* eslint-disable-next-line jsx-a11y/anchor-is-valid */}
-          <CollectionTitleText data-test-id="collection-link">
+          <CollectionTitleText
+            data-test-id="collection-link"
+            href={`/collections/${id}${isPrivate ? "/private" : ""}`}
+          >
             {name}
           </CollectionTitleText>
         </Link>

--- a/frontend/src/components/Header/index.tsx
+++ b/frontend/src/components/Header/index.tsx
@@ -25,9 +25,7 @@ const Header: FC = () => {
         <Right>
           {isMyCollectionsShown && (
             <Link href={ROUTES.MY_COLLECTIONS}>
-              {/* TODO(thuang): Remove the disable once the issue resolves: https://github.com/vercel/next.js/discussions/8207 */}
-              {/* eslint-disable-next-line jsx-a11y/anchor-is-valid */}
-              <a>
+              <a href={ROUTES.MY_COLLECTIONS}>
                 <MyCollectionsButton intent={Intent.PRIMARY} minimal>
                   My Collections
                 </MyCollectionsButton>

--- a/frontend/src/components/common/HomepageLink/index.tsx
+++ b/frontend/src/components/common/HomepageLink/index.tsx
@@ -6,9 +6,7 @@ import { Link } from "./style";
 export const HomepageLink: FC = () => {
   return (
     <Link href={ROUTES.HOMEPAGE}>
-      {/* TODO(thuang): Remove the disable once the issue resolves: https://github.com/vercel/next.js/discussions/8207 */}
-      {/* eslint-disable-next-line jsx-a11y/anchor-is-valid */}
-      <a>
+      <a href={ROUTES.HOMEPAGE}>
         <Logo />
       </a>
     </Link>


### PR DESCRIPTION
### Reviewers
**Functional:** 
@seve 

**Readability:** 
@Bento007 

---

## Changes
- add
- remove
- modify
Reverting https://github.com/chanzuckerberg/corpora-data-portal/pull/926/commits/16bcf03036105c883d1cab5bdfbe28c14b37f912 to add back `href` to anchor tags. Otherwise anchor tags won't function properly, such as on over showing the link URL and middle click to open the link in a new tab, etc.

PTAL thank you!

## Definition of Done (from ticket)

## QA steps (optional)

## Known Issues
