### PR TITLE
Add tests to run before deploys

### DIFF
--- a/.github/workflows/deploy-happy-stack.yml
+++ b/.github/workflows/deploy-happy-stack.yml
@@ -56,25 +56,23 @@ jobs:
           TFE_TOKEN: ${{ secrets.TFE_TOKEN }}
         run: |
           ./scripts/happy --profile="" --env ${{ github.event.deployment.environment }} update ${{ github.event.deployment.environment }}stack --tag ${{ github.event.deployment.payload.tag }}
-      ### This runs but is disabled because the local-functional-tests fail on staging, since it lacks a test_account_password secret value
-      ### and corpora_github_actions_dev role does not have permissions to run states:StartExecution.
-      # - name: Run functional test
-      #   env:
-      #     TFE_TOKEN: ${{ secrets.TFE_TOKEN }}
-      #     DEPLOYMENT_STAGE: ${{ github.event.deployment.environment }}
-      #   if: github.event.deployment.environment == 'stage'
-      #   run: |
-      #     echo "DOCKER_REPO=${DOCKER_REPO}" > .env.ecr
-      #     mkdir -p .local/bin
-      #     curl -Ls https://github.com/segmentio/chamber/releases/download/v2.9.1/chamber-v2.9.1-linux-amd64 > .local/bin/chamber &&
-      #     chmod +x .local/bin/chamber
-      #     PATH="$PATH:$(pwd)/.local/bin"
-      #     if [ "${DEPLOYMENT_STAGE}" == "stage" ]; then
-      #       export DEPLOYMENT_STAGE=staging
-      #     fi
-      #     echo DEPLOYMENT_STAGE ${DEPLOYMENT_STAGE}
-      #     docker-compose up --no-deps -d backend
-      #     BOTO_ENDPOINT_URL= make local-functional-test
+      - name: Run functional test
+        env:
+          TFE_TOKEN: ${{ secrets.TFE_TOKEN }}
+          DEPLOYMENT_STAGE: ${{ github.event.deployment.environment }}
+        if: github.event.deployment.environment != 'prod'
+        run: |
+          echo "DOCKER_REPO=${DOCKER_REPO}" > .env.ecr
+          mkdir -p .local/bin
+          curl -Ls https://github.com/segmentio/chamber/releases/download/v2.9.1/chamber-v2.9.1-linux-amd64 > .local/bin/chamber &&
+          chmod +x .local/bin/chamber
+          PATH="$PATH:$(pwd)/.local/bin"
+          if [ "${DEPLOYMENT_STAGE}" == "stage" ]; then
+            export DEPLOYMENT_STAGE=staging
+          fi
+          echo DEPLOYMENT_STAGE ${DEPLOYMENT_STAGE}
+          docker-compose up --no-deps -d backend
+          BOTO_ENDPOINT_URL= make local-functional-test
       ### Need to write success failure way because Github API doesn't allow doing
       ### "if: always(), state: ${{ success() }}:
       - name: Set deployment status to success if no errors

--- a/.github/workflows/deploy-happy-stack.yml
+++ b/.github/workflows/deploy-happy-stack.yml
@@ -73,6 +73,14 @@ jobs:
           echo DEPLOYMENT_STAGE ${DEPLOYMENT_STAGE}
           docker-compose up --no-deps -d backend
           BOTO_ENDPOINT_URL= make local-functional-test
+      - name: Run Smoke Tests
+        env:
+          DEPLOYMENT_STAGE: ${{ github.event.deployment.environment }}
+        run: |
+          if [ "${DEPLOYMENT_STAGE}" == "stage" ]; then
+            export DEPLOYMENT_STAGE=staging
+          fi
+          make local-e2e
       ### Need to write success failure way because Github API doesn't allow doing
       ### "if: always(), state: ${{ success() }}:
       - name: Set deployment status to success if no errors

--- a/Makefile
+++ b/Makefile
@@ -49,10 +49,6 @@ smoke-test-prod-build:
 smoke-test-with-local-backend:
 	$(MAKE) smoke-test-with-local-backend -C ./frontend
 
-.PHONY: smoke-test-with-local-backend-ci
-smoke-test-with-local-backend-ci:
-	$(MAKE) smoke-test-with-local-backend-ci -C ./frontend
-
 .PHONY: e2e
 e2e:
 	$(MAKE) e2e -C ./frontend DEPLOYMENT_STAGE=$(DEPLOYMENT_STAGE)

--- a/Makefile
+++ b/Makefile
@@ -182,6 +182,10 @@ local-functional-test: ## Run functional tests in the dev environment
 local-smoke-test: ## Run frontend/e2e tests in the dev environment
 	docker-compose exec -T frontend make smoke-test-with-local-dev
 
+.PHONY: local-e2e
+local-e2e: ## Run frontend/e2e tests
+	docker-compose exec -e DEPLOYMENT_STAGE -T frontend make e2e
+
 .PHONY: local-dbconsole
 local-dbconsole: ## Connect to the local postgres database.
 	psql "postgresql://corpora:test_pw@localhost:5432"

--- a/frontend/Makefile
+++ b/frontend/Makefile
@@ -42,10 +42,6 @@ smoke-test-prod-build:
 smoke-test-with-local-backend:
 	npm run smoke-test-with-local-backend
 
-.PHONY: smoke-test-with-local-backend-ci
-smoke-test-with-local-backend-ci:
-	npm run smoke-test-with-local-backend-ci
-
 .PHONY: e2e
 e2e:
 	npm run e2e-$(DEPLOYMENT_STAGE)

--- a/frontend/Makefile
+++ b/frontend/Makefile
@@ -44,7 +44,7 @@ smoke-test-with-local-backend:
 
 .PHONY: e2e
 e2e:
-	npm run e2e-$(DEPLOYMENT_STAGE)
+	TEST_ENV=$(DEPLOYMENT_STAGE) npm run e2e
 
 .PHONY: smoke-test-with-local-dev
 smoke-test-with-local-dev:

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -119,7 +119,6 @@ This starts an FE server that hits a **local** API server
 These are the commands we integrate in CI/CD pipeline for PR tests and
 after deployment tests
 
-1. PR: `npm run smoke-test-with-local-backend-ci`
 1. Dev: `npm run e2e-dev`
 1. Staging: `npm run e2e-staging`
 1. Prod: `npm run e2e-prod`

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -96,7 +96,7 @@
     "build-and-start-local-backend": "DEPLOYMENT_STAGE=test AWS_PROFILE=single-cell-dev npm run _build-and-start-local-backend",
     "smoke-test": "start-server-and-test start :3000 e2e",
     "smoke-test-prod-build": "start-server-and-test build-and-start-prod :9000 e2e-localProd",
-    "smoke-test-with-local-backend": "start-server-and-test build-and-start-local-backend :5000 build-and-start-prod :9000 e2e-localProd",
+    "smoke-test-with-local-backend": "start-server-and-test build-and-start-local-backend :5000 build-and-start-prod :9000 e2e-localProd"
   },
   "repository": {
     "type": "git",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -82,7 +82,7 @@
     "serve": "next start",
     "clean": "gatsby clean",
     "test": "jest jest/config.js",
-    "e2e": "TEST_ENV=local jest --config jest/e2e.config.js",
+    "e2e": "jest --config jest/e2e.config.js",
     "e2e-localProd": "TEST_ENV=localProd jest --config jest/e2e.config.js",
     "e2e-localProd-ci": "DEBUG=pw:api TEST_ENV=localProd jest --config jest/e2e.config.js",
     "e2e-dev": "TEST_ENV=dev jest --config jest/e2e.config.js",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -97,7 +97,6 @@
     "smoke-test": "start-server-and-test start :3000 e2e",
     "smoke-test-prod-build": "start-server-and-test build-and-start-prod :9000 e2e-localProd",
     "smoke-test-with-local-backend": "start-server-and-test build-and-start-local-backend :5000 build-and-start-prod :9000 e2e-localProd",
-    "smoke-test-with-local-backend-ci": "start-server-and-test build-and-start-local-backend-ci :5000 build-and-start-prod :9000 e2e-localProd-ci"
   },
   "repository": {
     "type": "git",

--- a/frontend/tests/common/constants.ts
+++ b/frontend/tests/common/constants.ts
@@ -1,6 +1,6 @@
 type TEST_ENV = "local" | "localProd" | "dev" | "staging" | "prod" | "rdev";
 
-export const TEST_ENV: TEST_ENV = (process.env.TEST_ENV as TEST_ENV) || "dev";
+export const TEST_ENV: TEST_ENV = (process.env.TEST_ENV as TEST_ENV) || "local";
 
 const TEST_ENV_TO_TEST_URL = {
   dev: "https://cellxgene.dev.single-cell.czi.technology",


### PR DESCRIPTION
* Remove unused smoke-test-with-local-backend-ci, @tihuan said it was dead
* Make TEST_ENV=local default for e2e tests, since dev environments going away with happy path
* Frontend make e2e now allows TEST_ENV environment variable to be passed through, without forcing to local
* Enable functional tests for staging deploys; added test passwords to staging
* Add e2e tests for staging deploys
