### PR TITLE
Double memory for backend containers.

### DIFF
--- a/.happy/terraform/modules/ecs-stack/main.tf
+++ b/.happy/terraform/modules/ecs-stack/main.tf
@@ -111,6 +111,7 @@ module backend_service {
   security_groups   = local.security_groups
   task_role_arn     = local.ecs_role_arn
   service_port      = 5000
+  memory            = 1536
   cmd               = local.backend_cmd
   deployment_stage  = local.deployment_stage
   step_function_arn = module.upload_sfn.step_function_arn

--- a/.happy/terraform/modules/service/main.tf
+++ b/.happy/terraform/modules/service/main.tf
@@ -33,7 +33,7 @@ resource aws_ecs_task_definition task_definition {
     "name": "web",
     "essential": true,
     "image": "${var.image}",
-    "memory": 768,
+    "memory": ${var.memory},
     "environment": [
       {
         "name": "REMOTE_DEV_PREFIX",

--- a/.happy/terraform/modules/service/variables.tf
+++ b/.happy/terraform/modules/service/variables.tf
@@ -104,6 +104,12 @@ variable priority {
   description = "Listener rule priority number within the given listener"
 }
 
+variable memory {
+  type        = number
+  description = "Amount of memory to allocate to each task"
+  default     = 768
+}
+
 variable wait_for_steady_state {
   type        = bool
   description = "Whether Terraform should block until the service is in a steady state before exiting"


### PR DESCRIPTION
This doubles the memory allocated to backend API containers. We were seeing some memory allocation failures in the prod container logs.

This has been tested in the jgadling2 rdev stack, all backend tasks now have 1536mb memory, and frontend tasks have 768m

### Reviewers
**Functional:** 

**Readability:** 

---

## Changes
- add
- remove
- modify

## Definition of Done (from ticket)

## QA steps (optional)

## Known Issues
