### PR TITLE
Fix: oidc runs on port 8443 rather than portmapping

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -164,7 +164,7 @@ services:
     image: soluto/oidc-server-mock:0.3.0
     ports:
       - "4011:80"
-      - "8443:443"
+      - "8443:8443"
     environment:
       ASPNETCORE_ENVIRONMENT: Development
       SERVER_OPTIONS_INLINE: |
@@ -178,7 +178,7 @@ services:
       API_RESOURCES_PATH: /tmp/config/api_resources.json
       USERS_CONFIGURATION_PATH: /tmp/config/users.json
       CLIENTS_CONFIGURATION_PATH: /tmp/config/clients-config.json
-      ASPNETCORE_URLS: https://+:443;http://+:80
+      ASPNETCORE_URLS: https://+:8443;http://+:80
       # ASPNETCORE_Kestrel__Certificates__Default__Password: <password for pfx file>
       ASPNETCORE_Kestrel__Certificates__Default__Path: /tmp/pkcs12/certificate.pfx
     volumes:


### PR DESCRIPTION
### Reviewers
**Functional:** 
This makes the OIDC app run natively on port 8443 instead of mapping the container's internal port 443 to the OSX hosts's port 8443. This makes it possible for other containers to reach the oidc service on port 8443 as well as engineers' web browsers

**Readability:** 

---

## Changes
- add
- remove
- modify

## Definition of Done (from ticket)

## QA steps (optional)

## Known Issues
