### PR TITLE
Handle workspaces without any latest config version

### DIFF
--- a/scripts/happy
+++ b/scripts/happy
@@ -266,6 +266,9 @@ class Stack:
 
     def destroy(self):
         self._ensure_workspace()
+        if not self.workspace.latest_config_version_id:
+            print("WARNING: No latest version of workspace to destroy. Assuming already empty and continuing.")
+            return True
         self.workspace.run(is_destroy=True)
         return self.workspace.wait()
 


### PR DESCRIPTION
The happy path script breaks if a previous run created a stack's workspace
without actually creating any workspace state or workspace config versions,
and you try to delete that workspace.

This PR prevents us from crashing in these cases, instead printing a warning
that the workspace is empty. Since the workspace is empty, this should not
be harmful.