### PR TITLE
Dunitz/934 collection geneset deletion

### DIFF
--- a/backend/corpora/common/entities/collection.py
+++ b/backend/corpora/common/entities/collection.py
@@ -4,6 +4,7 @@ from sqlalchemy import and_
 
 from . import Dataset
 from .entity import Entity
+from .geneset import Geneset
 from ..corpora_orm import DbCollection, DbCollectionLink, CollectionVisibility
 from ..utils.db_session import clone
 
@@ -170,7 +171,8 @@ class Collection(Entity):
 
     def tombstone_collection(self):
         self.update(tombstone=True)
-
+        for geneset in self.genesets:
+            Geneset.get(self.session, geneset.id).delete()
         for dataset in self.datasets:
             ds = Dataset.get(self.session, dataset.id, include_tombstones=True)
             ds.dataset_and_asset_deletion()

--- a/tests/unit/backend/corpora/common/entities/test_collection.py
+++ b/tests/unit/backend/corpora/common/entities/test_collection.py
@@ -217,3 +217,5 @@ class TestCollection(DataPortalTestCase):
         self.assertEqual(len(collection.datasets), 2)
         for dataset in collection.datasets:
             self.assertTrue(dataset.tombstone)
+
+    def test_tombstone_collection_deletes_all_genesets_in_collection(self):

--- a/tests/unit/backend/corpora/common/entities/test_collection.py
+++ b/tests/unit/backend/corpora/common/entities/test_collection.py
@@ -232,15 +232,13 @@ class TestCollection(DataPortalTestCase):
         self.assertIsNotNone(gs_ds_link)
         collection.tombstone_collection()
 
-        # check geneset deleted
+        # check gene sets deleted
         geneset = Geneset.get(session=self.session, key=geneset0.id)
         self.assertIsNone(geneset)
         geneset = Geneset.get(session=self.session, key=geneset1.id)
         self.assertIsNone(geneset)
+        self.assertEqual(len(collection.genesets), 0)
 
         # check geneset dataset links removed
         gs_ds_link = GenesetDatasetLink.get(session=self.session, geneset_id=geneset0.id, dataset_id=dataset.id)
         self.assertIsNone(gs_ds_link)
-
-
-


### PR DESCRIPTION
### Reviewers
**Functional:** 
- @Bento007 
**Readability:** 
- @seve 
---

## Changes
- add deletion of all genesets in a collection to collection deletion
- see https://app.zenhub.com/workspaces/single-cell-5e2a191dad828d52cc78b028/issues/chanzuckerberg/corpora-data-portal/934

## Definition of Done (from ticket)
- A tombstoned collection has no linked genesets
- Any genesets that belong to a tombstoned collection are no longer in the database
## QA steps (optional)

## Known Issues
