### PR TITLE
thuang-988-disable-autocomplete

### DIFF
--- a/frontend/src/components/common/Form/Input/index.tsx
+++ b/frontend/src/components/common/Form/Input/index.tsx
@@ -1,10 +1,10 @@
-import { FormGroup, InputGroup, Intent } from "@blueprintjs/core";
+import { FormGroup, Intent } from "@blueprintjs/core";
 import { IconNames } from "@blueprintjs/icons";
 import debounce from "lodash/debounce";
 import React, { FC, useRef, useState } from "react";
 import { DEBOUNCE_TIME_MS } from "../../../CreateCollectionModal/components/Content/common/constants";
 import { Value } from "../common/constants";
-import { LabelText, StyledIcon, StyledLabel } from "./style";
+import { LabelText, StyledIcon, StyledInputGroup, StyledLabel } from "./style";
 
 interface Props {
   name: string;
@@ -44,7 +44,11 @@ const Input: FC<Props> = ({
         intent={(!isValid && Intent.DANGER) || undefined}
       >
         <LabelText>{text}</LabelText>
-        <InputGroup
+        <StyledInputGroup
+          // (thuang): `autoComplete="off"` and `type="search"` are needed to stop autofill
+          // https://stackoverflow.com/a/30873633
+          autoComplete="off"
+          type="search"
           inputRef={inputRef}
           intent={(!isValid && Intent.DANGER) || undefined}
           id={name}

--- a/frontend/src/components/common/Form/Input/style.ts
+++ b/frontend/src/components/common/Form/Input/style.ts
@@ -1,4 +1,4 @@
-import { Icon, Label } from "@blueprintjs/core";
+import { Icon, InputGroup, Label } from "@blueprintjs/core";
 import { DARK_GRAY, PT_GRID_SIZE_PX } from "src/components/common/theme";
 import styled from "styled-components";
 
@@ -24,4 +24,10 @@ export const IconWrapper = styled.div`
 
 export const StyledIcon = styled(Icon)`
   margin-right: ${PT_GRID_SIZE_PX}px;
+`;
+
+export const StyledInputGroup = styled(InputGroup)`
+  && input {
+    border-radius: unset;
+  }
 `;


### PR DESCRIPTION
https://app.zenhub.com/workspaces/single-cell-5e2a191dad828d52cc78b028/issues/chanzuckerberg/corpora-data-portal/988

#988 

Related to https://github.com/chanzuckerberg/corpora-data-portal/pull/1033

### Reviewers
**Functional:** 
@seve 

**Readability:** 
@Bento007 

---

## Changes
Following https://stackoverflow.com/a/30873633 to add `type="search"` and `autocompete="off"` to each input field. This seems to stop autocomplete for me!

Seems like Chrome (and any browser) has the right to ignore `autocomplete="off"` for user protection, so the latest workaround is the combination above 🤞 

Another backup option is https://flaviocopes.com/react-form-browser-autofill/, which is not ideal, since it touches things that should be controlled by React, but should reliably work. Definitely the last resort and not a scalable solution

## Definition of Done (from ticket)

## QA steps (optional)
![demo](https://user-images.githubusercontent.com/6309723/113816861-495a3000-972a-11eb-9c32-6fae3b1ace47.gif)


## Known Issues
