### PR TITLE
thuang-fix-nextjs-multiservers

### DIFF
--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -1,5 +1,9 @@
 const withImages = require("next-images");
 
+const execSync = require("child_process").execSync;
+
+const lastCommitCommand = "git rev-parse HEAD";
+
 const configs = require(__dirname + "/src/configs/configs.js");
 const nodeEnv = require(__dirname + "/src/common/constants/nodeEnv.js");
 
@@ -11,6 +15,13 @@ const SCRIPT_SRC = ["'self'"];
 
 module.exports = withImages({
   future: { webpack5: true },
+
+  // (thuang): This is needed to ensure different Next.js servers can handle
+  // the same static asset requests
+  // https://github.com/vercel/next.js/issues/18389
+  async generateBuildId() {
+    return execSync(lastCommitCommand).toString().trim();
+  },
 
   headers() {
     return [


### PR DESCRIPTION
### Reviewers
**Functional:** 
@seve 
**Readability:** 
@maniarathi 

---

## Changes

Fixes deployed FE containers sometimes not being able to resolve static files such as `/_ssgManifest.js` and `buildManifest.js`, returning 404

<img width="866" alt="Screen Shot 2021-04-09 at 8 47 52 AM" src="https://user-images.githubusercontent.com/6309723/114207079-d7900b00-9910-11eb-9582-4e9e741376e9.png">

The root cause is that every Nextjs prod build has a unique build id for their static assets, which means if we have multiple FE instances running in a cluster, load balancer will sometimes route a static asset request to a different instance, which won't have the static asset with that build id.

The solution is to have build id based on the last commit hash, so the build id is the same across different FE instances!

Sources:

https://github.com/vercel/next.js/issues/18389
https://nextjs.org/docs/api-reference/next.config.js/configuring-the-build-id

## Definition of Done (from ticket)
After deploying to staging and prod, we should no longer get 404 for `ssgManifest.js` and `buildManifest.js`

## QA steps (optional)

## Known Issues
N/A