### PR TITLE
Pass BOTO_ENDPOINT_URL when running smoke tests

### DIFF
--- a/.github/workflows/deploy-happy-stack.yml
+++ b/.github/workflows/deploy-happy-stack.yml
@@ -64,7 +64,7 @@ jobs:
           if [ "${DEPLOYMENT_STAGE}" == "stage" ]; then
             export DEPLOYMENT_STAGE=staging
           fi
-          make local-e2e
+          BOTO_ENDPOINT_URL= make local-e2e
       - name: Run functional test
         env:
           TFE_TOKEN: ${{ secrets.TFE_TOKEN }}

--- a/Makefile
+++ b/Makefile
@@ -192,7 +192,10 @@ local-smoke-test: ## Run frontend/e2e tests in the dev environment
 
 .PHONY: local-e2e
 local-e2e: ## Run frontend/e2e tests
-	docker-compose $(COMPOSE_OPTS) run --no-deps -e DEPLOYMENT_STAGE -e AWS_REGION -e AWS_DEFAULT_REGION -e AWS_ACCESS_KEY_ID -e AWS_SECRET_ACCESS_KEY -T frontend make e2e
+	if [ -n "$${BOTO_ENDPOINT_URL+set}" ]; then \
+		EXTRA_ARGS="-e BOTO_ENDPOINT_URL"; \
+	fi; \
+	docker-compose $(COMPOSE_OPTS) run --no-deps -e DEPLOYMENT_STAGE -e AWS_REGION -e AWS_DEFAULT_REGION -e AWS_ACCESS_KEY_ID -e AWS_SECRET_ACCESS_KEY -e AWS_SESSION_TOKEN $${EXTRA_ARGS} -T frontend make e2e
 
 .PHONY: local-dbconsole
 local-dbconsole: ## Connect to the local postgres database.


### PR DESCRIPTION
Allows passing BOTO_ENDPOINT_URL when running frontend smoke tests,
so that it can access the AWS secrets. Also modifies the Happy CI
deploy script to set BOTO_ENDPOINT_URL to empty.

Gets us past the localstack issue, but unclear if it fixes everything;
Playwright still complains about being unable to access websocket on
127.0.0.1. However this at the minimum is part of the ultimate fix.
