### PR TITLE
rename gene_symbols in db, add test for order

### DIFF
--- a/backend/corpora/common/corpora_orm.py
+++ b/backend/corpora/common/corpora_orm.py
@@ -405,7 +405,7 @@ class DbGeneset(Base, AuditMixin):
 
     name = Column(String, nullable=False)
     description = Column(String)
-    gene_symbols = Column(JSONB)
+    genes = Column(JSONB)
     collection_id = Column(String, nullable=False)
     collection_visibility = Column(Enum(CollectionVisibility), nullable=False)
     collection = relationship("DbCollection", uselist=False, back_populates="genesets")

--- a/backend/corpora/common/entities/geneset.py
+++ b/backend/corpora/common/entities/geneset.py
@@ -10,8 +10,8 @@ class Geneset(Entity):
     table = DbGeneset
 
     @classmethod
-    def create(cls, session, name: str, description: str, gene_symbols: list, dataset_ids: list = [], **kwargs):
-        gene_set = DbGeneset(name=name, description=description, gene_symbols=gene_symbols, **kwargs)
+    def create(cls, session, name: str, description: str, genes: list, dataset_ids: list = [], **kwargs):
+        gene_set = DbGeneset(name=name, description=description, genes=genes, **kwargs)
         session.add(gene_set)
         session.commit()
         if dataset_ids:
@@ -27,7 +27,7 @@ class Geneset(Entity):
             reshaped_genesets.append(
                 geneset.to_dict(
                     remove_attr=[
-                        "gene_symbols",
+                        "genes",
                         "created_at",
                         "updated_at",
                         "collection",

--- a/backend/corpora/lambdas/api/v1/collection_uuid/gene_set.py
+++ b/backend/corpora/lambdas/api/v1/collection_uuid/gene_set.py
@@ -19,7 +19,7 @@ def post(collection_uuid: str, body: dict, user: str):
                 db_session,
                 name=gene_set["gene_set_name"],
                 description=gene_set["gene_set_description"],
-                gene_symbols=gene_set["genes"],
+                genes=gene_set["genes"],
                 collection_id=collection.id,
                 collection_visibility=collection.visibility.name,
             )

--- a/backend/corpora/lambdas/api/v1/dataset.py
+++ b/backend/corpora/lambdas/api/v1/dataset.py
@@ -97,7 +97,7 @@ def post_dataset_gene_sets(dataset_uuid: str, body: object, user: str):
                 "collection_id",
                 "created_at",
                 "updated_at",
-                "gene_symbols",
+                "genes",
             ]
         )
         for x in dataset.genesets

--- a/backend/database/versions/7685265932f6_rename_gene_symbols_field_to_genes.py
+++ b/backend/database/versions/7685265932f6_rename_gene_symbols_field_to_genes.py
@@ -6,11 +6,10 @@ Create Date: 2021-04-12 17:37:38.641573
 
 """
 from alembic import op
-import sqlalchemy as sa
 
 # revision identifiers, used by Alembic.
-revision = '7685265932f6'
-down_revision = '9a8dd669a47c'
+revision = "7685265932f6"
+down_revision = "9a8dd669a47c"
 branch_labels = None
 depends_on = None
 

--- a/backend/database/versions/7685265932f6_rename_gene_symbols_field_to_genes.py
+++ b/backend/database/versions/7685265932f6_rename_gene_symbols_field_to_genes.py
@@ -1,0 +1,23 @@
+"""rename_gene_symbols_field_to_genes
+
+Revision ID: 7685265932f6
+Revises: 9a8dd669a47c
+Create Date: 2021-04-12 17:37:38.641573
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = '7685265932f6'
+down_revision = '9a8dd669a47c'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.alter_column("geneset", "gene_symbols", new_column_name="genes")
+
+
+def downgrade():
+    op.alter_column("geneset", "genes", new_column_name="gene_symbols")

--- a/tests/unit/backend/chalice/api_server/collection_uuid/test_create_genesets.py
+++ b/tests/unit/backend/chalice/api_server/collection_uuid/test_create_genesets.py
@@ -66,14 +66,14 @@ class TestGenesetCreation(BaseAuthAPITest):
         geneset2 = Geneset.get(self.session, genesets["geneset2"])
         geneset3 = Geneset.get(self.session, genesets["geneset3"])
 
-        self.assertEqual(geneset1.gene_symbols, self.geneset1["genes"])
-        self.assertEqual(geneset2.gene_symbols, self.geneset2["genes"])
-        self.assertEqual(geneset3.gene_symbols, self.geneset3["genes"])
+        self.assertEqual(geneset1.genes, self.geneset1["genes"])
+        self.assertEqual(geneset2.genes, self.geneset2["genes"])
+        self.assertEqual(geneset3.genes, self.geneset3["genes"])
 
     def test_geneset_creation__geneset_already_exists(self):
         data = {"gene_sets": [self.geneset1]}
         Geneset.create(
-            self.session, collection=self.collection, name="geneset1", description="words", gene_symbols=["aaa"]
+            self.session, collection=self.collection, name="geneset1", description="words", genes=["aaa"]
         )
         response = self.app.post(self.test_url, headers=self.headers, data=json.dumps(data))
         self.assertEqual(400, response.status_code)

--- a/tests/unit/backend/chalice/api_server/collection_uuid/test_create_genesets.py
+++ b/tests/unit/backend/chalice/api_server/collection_uuid/test_create_genesets.py
@@ -72,9 +72,7 @@ class TestGenesetCreation(BaseAuthAPITest):
 
     def test_geneset_creation__geneset_already_exists(self):
         data = {"gene_sets": [self.geneset1]}
-        Geneset.create(
-            self.session, collection=self.collection, name="geneset1", description="words", genes=["aaa"]
-        )
+        Geneset.create(self.session, collection=self.collection, name="geneset1", description="words", genes=["aaa"])
         response = self.app.post(self.test_url, headers=self.headers, data=json.dumps(data))
         self.assertEqual(400, response.status_code)
 

--- a/tests/unit/backend/corpora/common/entities/test_genesets.py
+++ b/tests/unit/backend/corpora/common/entities/test_genesets.py
@@ -52,6 +52,19 @@ class TestGeneSets(DataPortalTestCase):
         self.assertIn(geneset_1.id, linked_geneset_ids)
         self.assertIn(geneset_2.id, linked_geneset_ids)
 
+    def test_gene_order_is_maintained(self):
+        collection = self.generate_collection(self.session)
+        genes = [
+            {"name": "a", "position": "first", "description": "words"},
+            {"name": "b", "position": "second", "description": "words"},
+            {"name": "c", "position": "third", "description": "words"},
+            {"name": "d", "position": "fourth", "description": "words"}]
+        geneset = self.generate_geneset(session=self.session, name="name", gene_symbols=genes, collection=collection)
+        self.session.flush()
+        geneset = Geneset.get(self.session, geneset.id)
+        self.assertEqual(geneset.gene_symbols[0], genes[0])
+        self.assertEqual(geneset.gene_symbols, genes)
+
 
 class TestGenesetDatasetLinks(DataPortalTestCase):
     def test_link_a_geneset_and_dataset(self):

--- a/tests/unit/backend/corpora/common/entities/test_genesets.py
+++ b/tests/unit/backend/corpora/common/entities/test_genesets.py
@@ -14,7 +14,7 @@ class TestGeneSets(DataPortalTestCase):
             self.session,
             name="geneset",
             description="words to describe it",
-            gene_symbols=["AAA", "BBB", "CCC"],
+            genes=["AAA", "BBB", "CCC"],
             collection=collection,
         )
         self.assertEqual(geneset.name, "geneset")
@@ -31,8 +31,8 @@ class TestGeneSets(DataPortalTestCase):
         stored_geneset = Geneset.get(self.session, geneset.id)
         self.assertIsInstance(stored_geneset.description, str)
         self.assertIsInstance(stored_geneset.name, str)
-        self.assertIsInstance(stored_geneset.gene_symbols, list)
-        self.assertGreater(len(stored_geneset.gene_symbols), 1)
+        self.assertIsInstance(stored_geneset.genes, list)
+        self.assertGreater(len(stored_geneset.genes), 1)
         self.assertIsNotNone(stored_geneset.collection)
         self.assertIsInstance(stored_geneset.collection, DbCollection)
 
@@ -59,11 +59,11 @@ class TestGeneSets(DataPortalTestCase):
             {"name": "b", "position": "second", "description": "words"},
             {"name": "c", "position": "third", "description": "words"},
             {"name": "d", "position": "fourth", "description": "words"}]
-        geneset = self.generate_geneset(session=self.session, name="name", gene_symbols=genes, collection=collection)
+        geneset = self.generate_geneset(session=self.session, name="name", genes=genes, collection=collection)
         self.session.flush()
         geneset = Geneset.get(self.session, geneset.id)
-        self.assertEqual(geneset.gene_symbols[0], genes[0])
-        self.assertEqual(geneset.gene_symbols, genes)
+        self.assertEqual(geneset.genes[0], genes[0])
+        self.assertEqual(geneset.genes, genes)
 
 
 class TestGenesetDatasetLinks(DataPortalTestCase):

--- a/tests/unit/backend/corpora/common/entities/test_genesets.py
+++ b/tests/unit/backend/corpora/common/entities/test_genesets.py
@@ -58,7 +58,8 @@ class TestGeneSets(DataPortalTestCase):
             {"name": "a", "position": "first", "description": "words"},
             {"name": "b", "position": "second", "description": "words"},
             {"name": "c", "position": "third", "description": "words"},
-            {"name": "d", "position": "fourth", "description": "words"}]
+            {"name": "d", "position": "fourth", "description": "words"},
+        ]
         geneset = self.generate_geneset(session=self.session, name="name", genes=genes, collection=collection)
         self.session.flush()
         geneset = Geneset.get(self.session, geneset.id)

--- a/tests/unit/backend/utils.py
+++ b/tests/unit/backend/utils.py
@@ -61,13 +61,13 @@ class BogusDatasetParams:
 class BogusGenesetParams:
     @classmethod
     def get(cls, **kwargs):
-        gene_symbols = []
+        genes = []
         for i in range(6):
-            gene_symbols.append(cls.generate_random_string(4))
+            genes.append(cls.generate_random_string(4))
         bogus_data = dict(
             description="This is a geneset bwhahaha",
             name=cls.generate_random_string(7),
-            gene_symbols=gene_symbols,
+            genes=genes,
             collection_id="test_collection_id",
             collection_visibility=CollectionVisibility.PUBLIC.name,
         )


### PR DESCRIPTION
### Reviewers
**Functional:** 
- @Bento007 
**Readability:** 

---

## Changes
- add test to ensure gene order is maintained
- modify gene_symbols to be genes for naming consistency.
Closes [957](https://app.zenhub.com/workspaces/single-cell-5e2a191dad828d52cc78b028/issues/chanzuckerberg/corpora-data-portal/957)
## Definition of Done (from ticket)
- geneset.genes returns a list of genes in the same order it was submitted

## QA steps (optional)

## Known Issues
