### PR TITLE
fix: remove incorrect redirect uri and outdated oauth config code

### DIFF
--- a/backend/corpora/common/corpora_config.py
+++ b/backend/corpora/common/corpora_config.py
@@ -51,11 +51,6 @@ class CorporaAuthConfig(SecretConfig):
             secret_name="auth0-secret",
             **kwargs,
         )
-        deployment = os.environ["DEPLOYMENT_STAGE"]
-        if not self.config_is_loaded():
-            self.load()
-        if deployment == "test":
-            self.config["callback_base_url"] = "http://localhost:5000"
 
     def get_defaults_template(self):
         template = {


### PR DESCRIPTION
### Reviewers
**Functional:**  @mbarrien 

----
### Notes

Smoke tests were failing because OIDC was failing to read the redirect URI sent from the backend (recieving  localhost instead of backend.corporanet.local)