### PR TITLE
Fix staging deploy IAM role assume

### DIFF
--- a/.github/workflows/deploy-happy-stack.yml
+++ b/.github/workflows/deploy-happy-stack.yml
@@ -20,9 +20,18 @@ jobs:
           aws-region: us-west-2
           role-to-assume: ${{ secrets.AWS_PROD_ROLE_TO_ASSUME }}
           role-duration-seconds: 900
+      - name: Configure AWS Staging Credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        if: github.event.deployment.environment == 'staging'
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-west-2
+          role-to-assume: ${{ secrets.AWS_STAGING_ROLE_TO_ASSUME }}
+          role-duration-seconds: 900
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1
-        if: github.event.deployment.environment != 'prod'
+        if: github.event.deployment.environment != 'prod' && github.event.deployment.environment != 'staging'
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/push-tests.yml
+++ b/.github/workflows/push-tests.yml
@@ -20,18 +20,8 @@ jobs:
   lint:
     runs-on: ubuntu-20.04
     steps:
-      - name: Configure AWS prod Credentials
-        uses: aws-actions/configure-aws-credentials@v1
-        if: github.event.deployment.environment == 'prod'
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: us-west-2
-          role-to-assume: ${{ secrets.AWS_PROD_ROLE_TO_ASSUME }}
-          role-duration-seconds: 900
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1
-        if: github.event.deployment.environment != 'prod'
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}


### PR DESCRIPTION
Fixes deployment issues for smoke tests on staging, where it
lack permissions to read the staging secrets because the
normal dev IAM role does not have permissions. We use the
existing unused staging IAM role, and store its ARN in a new
Github Actions secret AWS_STAGING_ROLE_TO_ASSUME. (Already
added manually to the repo.)

The IAM user used in CI already has permissions to
assume the existing CI IAM role.

While here, remove some code that isn't used during push tests;
the push tests are not run as part of a deployment workflow, so
it will never need to use the prod IAM role.
