### PR TITLE
Run more backend containers in prod.

### DIFF
--- a/.happy/terraform/envs/prod/main.tf
+++ b/.happy/terraform/envs/prod/main.tf
@@ -14,6 +14,7 @@ module stack {
   backend_url                  = "https://api.cellxgene.cziscience.com"
   stack_prefix                 = ""
   batch_container_memory_limit = 230000
+  backend_instance_count       = 6
 
   wait_for_steady_state        = var.wait_for_steady_state
 }

--- a/.happy/terraform/modules/ecs-stack/main.tf
+++ b/.happy/terraform/modules/ecs-stack/main.tf
@@ -82,7 +82,7 @@ module frontend_service {
   vpc               = local.vpc_id
   image             = "${local.frontend_image_repo}:${local.image_tag}"
   cluster           = local.cluster
-  desired_count     = 2
+  desired_count     = var.frontend_instance_count
   listener          = local.frontend_listener_arn
   subnets           = local.subnets
   security_groups   = local.security_groups
@@ -106,7 +106,7 @@ module backend_service {
   vpc               = local.vpc_id
   image             = "${local.backend_image_repo}:${local.image_tag}"
   cluster           = local.cluster
-  desired_count     = 2
+  desired_count     = var.backend_instance_count
   listener          = local.backend_listener_arn
   subnets           = local.subnets
   security_groups   = local.security_groups

--- a/.happy/terraform/modules/ecs-stack/variables.tf
+++ b/.happy/terraform/modules/ecs-stack/variables.tf
@@ -81,3 +81,15 @@ variable batch_container_memory_limit {
   description = "Memory hard limit for the batch container"
   default     = 28000
 }
+
+variable frontend_instance_count {
+  type        = number
+  description = "How many frontend tasks to run"
+  default     = 2
+}
+
+variable backend_instance_count {
+  type        = number
+  description = "How many backend tasks to run"
+  default     = 2
+}


### PR DESCRIPTION
This increases the number of backend workers available to service requests. Each backend container can process a max of 40 parallel requests, and prod is regularly exceeding our available worker count. We should look into adding an autoscaling policy for these services, but this PR will reduce errors in the meantime.

### Reviewers
**Functional:** 

**Readability:** 

---

## Changes
- add
- remove
- modify

## Definition of Done (from ticket)

## QA steps (optional)

## Known Issues
