### PR TITLE
e2e tests use secret for current deployment stage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -183,7 +183,7 @@ local-functional-test: ## Run functional tests in the dev environment
 		EXTRA_ARGS="-e BOTO_ENDPOINT_URL"; \
 	fi; \
 	chamber -b secretsmanager exec corpora/backend/$${DEPLOYMENT_STAGE}/auth0-secret -- \
-		docker-compose exec -T -e CLIENT_ID -e CLIENT_SECRET -e TEST_ACCOUNT_PASSWORD -e DEPLOYMENT_STAGE -e AWS_ACCESS_KEY_ID -e AWS_SECRET_ACCESS_KEY -e AWS_SESSION_TOKEN $${EXTRA_ARGS} \
+		docker-compose exec -T -e CLIENT_ID -e CLIENT_SECRET -e TEST_ACCOUNT_USERNAME -e TEST_ACCOUNT_PASSWORD -e DEPLOYMENT_STAGE -e AWS_ACCESS_KEY_ID -e AWS_SECRET_ACCESS_KEY -e AWS_SESSION_TOKEN $${EXTRA_ARGS} \
 		backend bash -c "cd /corpora-data-portal && make container-functionaltest"
 
 .PHONY: local-smoke-test

--- a/frontend/jest/playwright-globalSetup.js
+++ b/frontend/jest/playwright-globalSetup.js
@@ -15,8 +15,10 @@ const client = new SecretsManagerClient({
   endpoint,
 });
 
+const deployment_stage = process.env.DEPLOYMENT_STAGE || "test";
+
 const secretValueRequest = {
-  SecretId: "corpora/backend/test/auth0-secret",
+  SecretId: `corpora/backend/${deployment_stage}/auth0-secret`,
 };
 
 const command = new GetSecretValueCommand(secretValueRequest);

--- a/tests/functional/backend/corpora/test_api.py
+++ b/tests/functional/backend/corpora/test_api.py
@@ -42,7 +42,7 @@ class TestApi(unittest.TestCase):
             headers={"content-type": "application/x-www-form-urlencoded"},
             data=dict(
                 grant_type="password",
-                username="user@example.com",
+                username=config.test_account_username,
                 password=config.test_account_password,
                 audience=AUDIENCE.get(cls.deployment_stage),
                 scope="openid profile email offline",


### PR DESCRIPTION
* Move the test_account_username into a secret, even for test stage
* Modify the playwright global setup to dynamically change secret
  name to read based on deployment stage
