### PR TITLE
Pass git commit at container build time, use a next.js build id

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,4 +37,11 @@ RUN mkdir -p chalicelib config vendor
 ADD backend/corpora chalicelib/corpora
 ADD backend/config/corpora-api.yml chalicelib/config/corpora-api.yml
 
+ARG HAPPY_BRANCH="unknown"
+ARG HAPPY_COMMIT="unknown"
+LABEL branch=${HAPPY_BRANCH}
+LABEL commit=${HAPPY_COMMIT}
+ENV COMMIT_SHA=${HAPPY_COMMIT}
+ENV COMMIT_BRANCH=${HAPPY_BRANCH}
+
 CMD ["python3", "/chalice/run_local_server.py"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -38,7 +38,7 @@ ADD backend/corpora chalicelib/corpora
 ADD backend/config/corpora-api.yml chalicelib/config/corpora-api.yml
 
 ARG HAPPY_BRANCH="unknown"
-ARG HAPPY_COMMIT="unknown"
+ARG HAPPY_COMMIT=""
 LABEL branch=${HAPPY_BRANCH}
 LABEL commit=${HAPPY_COMMIT}
 ENV COMMIT_SHA=${HAPPY_COMMIT}

--- a/Dockerfile.processing_image
+++ b/Dockerfile.processing_image
@@ -45,4 +45,11 @@ ADD backend/corpora/__init__.py backend/corpora/__init__.py
 ADD backend/corpora/dataset_processing backend/corpora/dataset_processing
 ADD backend/corpora/common backend/corpora/common
 
+ARG HAPPY_BRANCH="unknown"
+ARG HAPPY_COMMIT="unknown"
+LABEL branch=${HAPPY_BRANCH}
+LABEL commit=${HAPPY_COMMIT}
+ENV COMMIT_SHA=${HAPPY_COMMIT}
+ENV COMMIT_BRANCH=${HAPPY_BRANCH}
+
 CMD ["python3", "-m", "backend.corpora.dataset_processing.process"]

--- a/Dockerfile.processing_image
+++ b/Dockerfile.processing_image
@@ -46,7 +46,7 @@ ADD backend/corpora/dataset_processing backend/corpora/dataset_processing
 ADD backend/corpora/common backend/corpora/common
 
 ARG HAPPY_BRANCH="unknown"
-ARG HAPPY_COMMIT="unknown"
+ARG HAPPY_COMMIT=""
 LABEL branch=${HAPPY_BRANCH}
 LABEL commit=${HAPPY_COMMIT}
 ENV COMMIT_SHA=${HAPPY_COMMIT}

--- a/Dockerfile.upload_failures
+++ b/Dockerfile.upload_failures
@@ -13,7 +13,7 @@ COPY backend/corpora/dataset_processing ./chalicelib/backend/corpora/dataset_pro
 RUN mkdir -p ./.chalice
 
 ARG HAPPY_BRANCH="unknown"
-ARG HAPPY_COMMIT="unknown"
+ARG HAPPY_COMMIT=""
 LABEL branch=${HAPPY_BRANCH}
 LABEL commit=${HAPPY_COMMIT}
 ENV COMMIT_SHA=${HAPPY_COMMIT}

--- a/Dockerfile.upload_failures
+++ b/Dockerfile.upload_failures
@@ -12,4 +12,11 @@ COPY backend/corpora/common ./chalicelib/backend/corpora/common
 COPY backend/corpora/dataset_processing ./chalicelib/backend/corpora/dataset_processing
 RUN mkdir -p ./.chalice
 
+ARG HAPPY_BRANCH="unknown"
+ARG HAPPY_COMMIT="unknown"
+LABEL branch=${HAPPY_BRANCH}
+LABEL commit=${HAPPY_COMMIT}
+ENV COMMIT_SHA=${HAPPY_COMMIT}
+ENV COMMIT_BRANCH=${HAPPY_BRANCH}
+
 CMD ["app.handle_failure"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -41,6 +41,9 @@ services:
         - "${DOCKER_REPO}corpora-frontend:branch-main"
       args:
         - BUILDKIT_INLINE_CACHE=1
+        - HAPPY_COMMIT
+        - HAPPY_BRANCH
+        - HAPPY_TAG
     restart: always
     depends_on:
       - backend
@@ -70,6 +73,9 @@ services:
       dockerfile: Dockerfile.upload_failures
       args:
         - BUILDKIT_INLINE_CACHE=1
+        - HAPPY_COMMIT
+        - HAPPY_BRANCH
+        - HAPPY_TAG
     restart: "no"
     ports:
       - "9000:8080"
@@ -102,6 +108,9 @@ services:
       dockerfile: Dockerfile.processing_image
       args:
         - BUILDKIT_INLINE_CACHE=1
+        - HAPPY_COMMIT
+        - HAPPY_BRANCH
+        - HAPPY_TAG
     restart: "no"
     volumes:
       - ./backend/corpora/dataset_processing:/backend/corpora/dataset_processing
@@ -130,6 +139,9 @@ services:
         - "${DOCKER_REPO}corpora-backend:branch-main"
       args:
         - BUILDKIT_INLINE_CACHE=1
+        - HAPPY_COMMIT
+        - HAPPY_BRANCH
+        - HAPPY_TAG
     restart: always
     depends_on:
       - localstack

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -27,7 +27,7 @@ ADD . /corpora-frontend
 WORKDIR /corpora-frontend
 
 ARG HAPPY_BRANCH="unknown"
-ARG HAPPY_COMMIT="unknown"
+ARG HAPPY_COMMIT=""
 LABEL branch=${HAPPY_BRANCH}
 LABEL commit=${HAPPY_COMMIT}
 ENV COMMIT_SHA=${HAPPY_COMMIT}

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -26,4 +26,11 @@ RUN apt-get update && apt-get install -y \
 ADD . /corpora-frontend
 WORKDIR /corpora-frontend
 
+ARG HAPPY_BRANCH="unknown"
+ARG HAPPY_COMMIT="unknown"
+LABEL branch=${HAPPY_BRANCH}
+LABEL commit=${HAPPY_COMMIT}
+ENV COMMIT_SHA=${HAPPY_COMMIT}
+ENV COMMIT_BRANCH=${HAPPY_BRANCH}
+
 ENTRYPOINT ["./container_init.sh"]

--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -12,6 +12,12 @@ const SCRIPT_SRC = ["'self'"];
 module.exports = withImages({
   future: { webpack5: true },
 
+  async generateBuildId() {
+    // Return null to allow next.js to fallback to default behavior
+    // if COMMIT_SHA env is missing or empty.
+    return process.env.COMMIT_SHA || null;
+  },
+
   headers() {
     return [
       {

--- a/scripts/happy
+++ b/scripts/happy
@@ -788,6 +788,13 @@ class Orchestrator:
         print("done!")
 
 
+def subprocess_output_with_default(cmd, default="unknown"):
+    try:
+        return subprocess.check_output(cmd).decode().strip()
+    except subprocess.CalledProcessError:
+        return default
+
+
 class ArtifactBuilder:
     """Builds artifacts such asx Docker containers. For now, this is hard coded to use docker-compose as the backend."""
 
@@ -802,6 +809,9 @@ class ArtifactBuilder:
         env["BUILDKIT_INLINE_CACHE"] = "1"
         env["COMPOSE_DOCKER_CLI_BUILD"] = "1"
         env["DOCKER_REPO"] = f"{self.config['ecr_repo']}/"
+        env["HAPPY_COMMIT"] = subprocess_output_with_default(["git", "rev-parse", "--verify", "HEAD"])
+        env["HAPPY_BRANCH"] = subprocess_output_with_default(["git", "branch", "--show-current"])
+        env["HAPPY_TAG"] = subprocess_output_with_default(["git", "describe"])
         return env
 
     def build(self, artifacts=None):


### PR DESCRIPTION
* Make the current Git branch, commit hash, and tag description be
  added as Docker build-time arguments.
* Modify containers to add those as labels embedded within the image
* Override next.js build ID to use the commit hash, falling back to
  default random ID behavior if commit hash not provided.

Ideally we'd rather build the next build artifact right into the
container image, so a 2nd container using the same image would have
the same build ID for free (and there's no build time at startup).
However, we cannot run `npm run build` on the bare image because
even running this requires a configs/config.js file to be present,
which it isn't at the time we initially build the Dockerfile.
