### PR TITLE
feat: Allow for users to update their collections and add names to links

### DIFF
--- a/backend/corpora/common/entities/collection.py
+++ b/backend/corpora/common/entities/collection.py
@@ -184,13 +184,13 @@ class Collection(Entity):
          be removed and replaced with new entries.
         :param kwargs: Any other fields in the dataset that will be replaced.
         """
-        if links:
-            for link in self.links:
-                self.session.delete(link)
-            new_objs = [
-                DbCollectionLink(collection_id=self.id, collection_visibility=self.visibility, **link) for link in links
-            ]
-            self.session.add_all(new_objs)
-            self.session.flush()
+        links = links if links else []
+        for link in self.links:
+            self.session.delete(link)
+        new_objs = [
+            DbCollectionLink(collection_id=self.id, collection_visibility=self.visibility, **link) for link in links
+        ]
+        self.session.add_all(new_objs)
+        self.session.flush()
 
         super().update(**kwargs)

--- a/frontend/src/common/queries/collections.ts
+++ b/frontend/src/common/queries/collections.ts
@@ -220,10 +220,13 @@ export function usePublishCollection() {
   });
 }
 
-async function editCollection(
-  id: string,
-  payload: string
-): Promise<Collection> {
+const editCollection = async function ({
+  id,
+  payload,
+}: {
+  id: string;
+  payload: string;
+}): Promise<Collection> {
   if (!id) {
     throw Error("No id given");
   } else if (!payload) {
@@ -243,7 +246,7 @@ async function editCollection(
 
   if (!response.ok) throw result;
   return result;
-}
+};
 
 export function useEditCollection() {
   const queryCache = useQueryCache();

--- a/frontend/src/common/queries/common.ts
+++ b/frontend/src/common/queries/common.ts
@@ -6,3 +6,9 @@ export const DELETE_FETCH_OPTIONS: RequestInit = {
   credentials: "include",
   method: "DELETE",
 };
+
+export const JSON_BODY_FETCH_OPTIONS: RequestInit = {
+  headers: {
+    "Content-Type": "application/json",
+  },
+};

--- a/frontend/src/components/CreateCollectionModal/components/Content/components/AddLink/index.tsx
+++ b/frontend/src/components/CreateCollectionModal/components/Content/components/AddLink/index.tsx
@@ -39,7 +39,7 @@ const AddLink: FC<AddLinkProps> = ({ handleClick, Button }) => {
     <Popover
       content={<LinkTypes handleClick={handleClick} />}
       position={Position.BOTTOM_LEFT}
-      captureDismiss={true}
+      captureDismiss={true} // Not setting this led to this ridiculously obfuscated bug where choosing a link type would close the menu that held the edit collection button. Closing that menu would close the entire edit collection modal
     >
       <Button />
     </Popover>

--- a/frontend/src/components/CreateCollectionModal/components/Content/components/AddLink/index.tsx
+++ b/frontend/src/components/CreateCollectionModal/components/Content/components/AddLink/index.tsx
@@ -1,11 +1,4 @@
-import {
-  Button,
-  Intent,
-  Menu,
-  MenuItem,
-  Popover,
-  Position,
-} from "@blueprintjs/core";
+import { Menu, MenuItem, Popover, Position } from "@blueprintjs/core";
 import React, { FC } from "react";
 import {
   COLLECTION_LINK_TYPE,
@@ -14,6 +7,10 @@ import {
 
 interface Props {
   handleClick: (type: COLLECTION_LINK_TYPE) => void;
+}
+
+interface AddLinkProps extends Props {
+  Button: React.ElementType;
 }
 
 const OPTION_ORDER = [
@@ -37,15 +34,13 @@ const LinkTypes: FC<Props> = ({ handleClick }) => {
   );
 };
 
-const AddLink: FC<Props> = ({ handleClick }) => {
+const AddLink: FC<AddLinkProps> = ({ handleClick, Button }) => {
   return (
     <Popover
       content={<LinkTypes handleClick={handleClick} />}
       position={Position.BOTTOM_LEFT}
     >
-      <Button outlined intent={Intent.PRIMARY}>
-        Add Link
-      </Button>
+      <Button />
     </Popover>
   );
 };

--- a/frontend/src/components/CreateCollectionModal/components/Content/components/AddLink/index.tsx
+++ b/frontend/src/components/CreateCollectionModal/components/Content/components/AddLink/index.tsx
@@ -39,6 +39,7 @@ const AddLink: FC<AddLinkProps> = ({ handleClick, Button }) => {
     <Popover
       content={<LinkTypes handleClick={handleClick} />}
       position={Position.BOTTOM_LEFT}
+      captureDismiss={true}
     >
       <Button />
     </Popover>

--- a/frontend/src/components/CreateCollectionModal/components/Content/components/LinkInput/index.tsx
+++ b/frontend/src/components/CreateCollectionModal/components/Content/components/LinkInput/index.tsx
@@ -1,7 +1,7 @@
 import { Button } from "@blueprintjs/core";
 import { IconNames } from "@blueprintjs/icons";
 import { debounce } from "lodash";
-import React, { FC, useEffect, useState } from "react";
+import React, { FC } from "react";
 import {
   COLLECTION_LINK_TYPE,
   COLLECTION_LINK_TYPE_OPTIONS,
@@ -14,23 +14,24 @@ import { IconWrapper, LinkWrapper, StyledButton } from "./style";
 
 export type LinkValue = {
   id: number;
-  value: string;
+  url: string;
   isValid: boolean;
   index: number;
-  name: string;
+  linkName: string;
+  linkType: COLLECTION_LINK_TYPE;
 };
 
 const DOI_PLACEHOLDER = "https://doi.org/10.1126/science.aax6234";
 const LINK_PLACEHOLDER = "https://cellxgene.cziscience.com";
 
 interface Props {
-  handleChange: ({ id, value, isValid }: LinkValue) => void;
+  handleChange: ({ id, url, isValid }: LinkValue) => void;
   id: number;
   index: number;
-  type: COLLECTION_LINK_TYPE;
+  linkName: string;
+  linkType: COLLECTION_LINK_TYPE;
   handleDelete: (id: number) => void;
-  defaultValue: string;
-  name: string;
+  url: string;
   isValid: boolean;
 }
 
@@ -38,26 +39,18 @@ const LinkInput: FC<Props> = ({
   handleChange,
   handleDelete,
   id,
-  type,
+  linkType,
   index,
-  defaultValue,
-  name: defaultName,
+  url,
+  linkName,
   isValid,
 }) => {
-  const option = COLLECTION_LINK_TYPE_OPTIONS[type];
-
+  const option = COLLECTION_LINK_TYPE_OPTIONS[linkType];
   const { text, value } = option;
-
-  const [name, setName] = useState(defaultName);
-  const [linkType, setLinkType] = useState(value as COLLECTION_LINK_TYPE);
-
-  useEffect(() => {
-    handleChange_({ isValid, value: defaultValue });
-  }, [name, linkType]);
 
   const LinkTypeButton = () => (
     <Button minimal={true} rightIcon="caret-down">
-      {COLLECTION_LINK_TYPE_OPTIONS[linkType].text}
+      {text}
     </Button>
   );
 
@@ -65,11 +58,11 @@ const LinkInput: FC<Props> = ({
     <LinkWrapper>
       <AddLink handleClick={handleLinkTypeChange} Button={LinkTypeButton} />
       <Input
-        name={value}
-        text="Name"
+        name="Name"
+        text="Name(optional)"
         placeholder="Name"
         handleChange={handleNameChange}
-        defaultValue={defaultName}
+        defaultValue={linkName}
       />
       <Input
         name={value}
@@ -80,7 +73,7 @@ const LinkInput: FC<Props> = ({
             ? DOI_PLACEHOLDER
             : LINK_PLACEHOLDER
         }
-        defaultValue={defaultValue}
+        defaultValue={url}
         handleChange={debounce(handleChange_, DEBOUNCE_TIME_MS)}
       />
       <IconWrapper>
@@ -94,11 +87,30 @@ const LinkInput: FC<Props> = ({
     </LinkWrapper>
   );
 
-  function handleNameChange({ value }: { isValid: boolean; value: string }) {
-    setName(value);
+  function handleNameChange({
+    value: newLinkName,
+  }: {
+    isValid: boolean;
+    value: string;
+  }) {
+    handleChange({
+      id,
+      index,
+      isValid,
+      linkName: newLinkName,
+      linkType,
+      url,
+    });
   }
   function handleLinkTypeChange(newLinkType: COLLECTION_LINK_TYPE) {
-    setLinkType(newLinkType);
+    handleChange({
+      id,
+      index,
+      isValid,
+      linkName,
+      linkType: newLinkType,
+      url,
+    });
   }
 
   function handleChange_({
@@ -112,8 +124,9 @@ const LinkInput: FC<Props> = ({
       id,
       index,
       isValid: isValidFromInput,
-      name,
-      value,
+      linkName,
+      linkType,
+      url: value,
     });
   }
 };

--- a/frontend/src/components/CreateCollectionModal/components/Content/components/LinkInput/index.tsx
+++ b/frontend/src/components/CreateCollectionModal/components/Content/components/LinkInput/index.tsx
@@ -1,4 +1,3 @@
-import { Button } from "@blueprintjs/core";
 import { IconNames } from "@blueprintjs/icons";
 import { debounce } from "lodash";
 import React, { FC } from "react";
@@ -7,10 +6,17 @@ import {
   COLLECTION_LINK_TYPE_OPTIONS,
 } from "src/common/entities";
 import Input from "src/components/common/Form/Input";
+import { LabelText, StyledDiv } from "src/components/common/Form/Input/style";
 import { GRAY } from "src/components/common/theme";
 import { DEBOUNCE_TIME_MS } from "../../common/constants";
 import AddLink from "../AddLink";
-import { IconWrapper, LinkWrapper, StyledButton } from "./style";
+import {
+  IconWrapper,
+  LinkWrapper,
+  StyledButton,
+  StyledLinkTypeButton,
+  StyledURLInput,
+} from "./style";
 
 export type LinkValue = {
   id: number;
@@ -49,9 +55,12 @@ const LinkInput: FC<Props> = ({
   const { text, value } = option;
 
   const LinkTypeButton = () => (
-    <Button minimal={true} rightIcon="caret-down">
-      {text}
-    </Button>
+    <StyledDiv>
+      <LabelText>Type</LabelText>
+      <StyledLinkTypeButton outlined minimal={true} rightIcon="caret-down">
+        {text}
+      </StyledLinkTypeButton>
+    </StyledDiv>
   );
 
   return (
@@ -63,8 +72,9 @@ const LinkInput: FC<Props> = ({
         placeholder="Name"
         handleChange={handleNameChange}
         defaultValue={linkName}
+        percentage={25}
       />
-      <Input
+      <StyledURLInput
         name={value}
         text="URL"
         syncValidation={[isValidHttpUrl, isDOILink(value)]}
@@ -75,6 +85,7 @@ const LinkInput: FC<Props> = ({
         }
         defaultValue={url}
         handleChange={debounce(handleChange_, DEBOUNCE_TIME_MS)}
+        percentage={40}
       />
       <IconWrapper>
         <StyledButton

--- a/frontend/src/components/CreateCollectionModal/components/Content/components/LinkInput/index.tsx
+++ b/frontend/src/components/CreateCollectionModal/components/Content/components/LinkInput/index.tsx
@@ -1,5 +1,4 @@
 import { IconNames } from "@blueprintjs/icons";
-import { debounce } from "lodash";
 import React, { FC } from "react";
 import {
   COLLECTION_LINK_TYPE,
@@ -8,7 +7,6 @@ import {
 import Input from "src/components/common/Form/Input";
 import { LabelText, StyledDiv } from "src/components/common/Form/Input/style";
 import { GRAY } from "src/components/common/theme";
-import { DEBOUNCE_TIME_MS } from "../../common/constants";
 import AddLink from "../AddLink";
 import {
   IconWrapper,
@@ -84,7 +82,7 @@ const LinkInput: FC<Props> = ({
             : LINK_PLACEHOLDER
         }
         defaultValue={url}
-        handleChange={debounce(handleChange_, DEBOUNCE_TIME_MS)}
+        handleChange={handleChange_}
         percentage={40}
       />
       <IconWrapper>

--- a/frontend/src/components/CreateCollectionModal/components/Content/components/LinkInput/index.tsx
+++ b/frontend/src/components/CreateCollectionModal/components/Content/components/LinkInput/index.tsx
@@ -26,6 +26,7 @@ interface Props {
   index: number;
   type: COLLECTION_LINK_TYPE;
   handleDelete: (id: number) => void;
+  defaultValue: string;
 }
 
 const LinkInput: FC<Props> = ({
@@ -34,6 +35,7 @@ const LinkInput: FC<Props> = ({
   id,
   type,
   index,
+  defaultValue,
 }) => {
   const option = COLLECTION_LINK_TYPE_OPTIONS[type];
 
@@ -52,6 +54,7 @@ const LinkInput: FC<Props> = ({
             ? DOI_PLACEHOLDER
             : LINK_PLACEHOLDER
         }
+        defaultValue={defaultValue}
       />
       <IconWrapper>
         <StyledButton

--- a/frontend/src/components/CreateCollectionModal/components/Content/components/LinkInput/index.tsx
+++ b/frontend/src/components/CreateCollectionModal/components/Content/components/LinkInput/index.tsx
@@ -1,20 +1,23 @@
+import { Button } from "@blueprintjs/core";
 import { IconNames } from "@blueprintjs/icons";
-import debounce from "lodash/debounce";
-import React, { FC } from "react";
+import { debounce } from "lodash";
+import React, { FC, useState } from "react";
 import {
   COLLECTION_LINK_TYPE,
   COLLECTION_LINK_TYPE_OPTIONS,
 } from "src/common/entities";
 import Input from "src/components/common/Form/Input";
 import { GRAY } from "src/components/common/theme";
-import { DEBOUNCE_TIME_MS } from "src/components/CreateCollectionModal/components/Content/common/constants";
-import { IconWrapper, StyledButton, Wrapper } from "./style";
+import { DEBOUNCE_TIME_MS } from "../../common/constants";
+import AddLink from "../AddLink";
+import { IconWrapper, LinkWrapper, StyledButton } from "./style";
 
 export type LinkValue = {
   id: number;
   value: string;
   isValid: boolean;
   index: number;
+  name: string;
 };
 
 const DOI_PLACEHOLDER = "https://doi.org/10.1126/science.aax6234";
@@ -41,20 +44,36 @@ const LinkInput: FC<Props> = ({
 
   const { text, value } = option;
 
+  const [name, setName] = useState("");
+  const [linkType, setLinkType] = useState(value as COLLECTION_LINK_TYPE);
+
+  const LinkTypeButton = () => (
+    <Button minimal={true} rightIcon="caret-down">
+      {COLLECTION_LINK_TYPE_OPTIONS[linkType].text}
+    </Button>
+  );
+
   return (
-    <Wrapper>
+    <LinkWrapper>
+      <AddLink handleClick={handleLinkTypeChange} Button={LinkTypeButton} />
+
       <Input
         name={value}
-        text={text}
-        handleChange={debounce(handleChange_, DEBOUNCE_TIME_MS)}
+        text="Name"
+        placeholder="Name"
+        handleChange={handleNameChange}
+      />
+      <Input
+        name={value}
+        text="URL"
         syncValidation={[isValidHttpUrl, isDOILink(value)]}
-        noNameAttr
         placeholder={
           value === COLLECTION_LINK_TYPE.DOI
             ? DOI_PLACEHOLDER
             : LINK_PLACEHOLDER
         }
         defaultValue={defaultValue}
+        handleChange={debounce(handleChange_, DEBOUNCE_TIME_MS)}
       />
       <IconWrapper>
         <StyledButton
@@ -64,8 +83,15 @@ const LinkInput: FC<Props> = ({
           onClick={() => handleDelete(id)}
         />
       </IconWrapper>
-    </Wrapper>
+    </LinkWrapper>
   );
+
+  function handleNameChange({ value }: { isValid: boolean; value: string }) {
+    setName(value);
+  }
+  function handleLinkTypeChange(newLinkType: COLLECTION_LINK_TYPE) {
+    setLinkType(newLinkType);
+  }
 
   function handleChange_({
     isValid: isValidFromInput,
@@ -74,7 +100,13 @@ const LinkInput: FC<Props> = ({
     isValid: boolean;
     value: string;
   }) {
-    handleChange({ id, index, isValid: isValidFromInput, value });
+    handleChange({
+      id,
+      index,
+      isValid: isValidFromInput,
+      name,
+      value,
+    });
   }
 };
 

--- a/frontend/src/components/CreateCollectionModal/components/Content/components/LinkInput/index.tsx
+++ b/frontend/src/components/CreateCollectionModal/components/Content/components/LinkInput/index.tsx
@@ -1,7 +1,7 @@
 import { Button } from "@blueprintjs/core";
 import { IconNames } from "@blueprintjs/icons";
 import { debounce } from "lodash";
-import React, { FC, useState } from "react";
+import React, { FC, useEffect, useState } from "react";
 import {
   COLLECTION_LINK_TYPE,
   COLLECTION_LINK_TYPE_OPTIONS,
@@ -30,6 +30,8 @@ interface Props {
   type: COLLECTION_LINK_TYPE;
   handleDelete: (id: number) => void;
   defaultValue: string;
+  name: string;
+  isValid: boolean;
 }
 
 const LinkInput: FC<Props> = ({
@@ -39,13 +41,19 @@ const LinkInput: FC<Props> = ({
   type,
   index,
   defaultValue,
+  name: defaultName,
+  isValid,
 }) => {
   const option = COLLECTION_LINK_TYPE_OPTIONS[type];
 
   const { text, value } = option;
 
-  const [name, setName] = useState("");
+  const [name, setName] = useState(defaultName);
   const [linkType, setLinkType] = useState(value as COLLECTION_LINK_TYPE);
+
+  useEffect(() => {
+    handleChange_({ isValid, value: defaultValue });
+  }, [name, linkType]);
 
   const LinkTypeButton = () => (
     <Button minimal={true} rightIcon="caret-down">
@@ -56,12 +64,12 @@ const LinkInput: FC<Props> = ({
   return (
     <LinkWrapper>
       <AddLink handleClick={handleLinkTypeChange} Button={LinkTypeButton} />
-
       <Input
         name={value}
         text="Name"
         placeholder="Name"
         handleChange={handleNameChange}
+        defaultValue={defaultName}
       />
       <Input
         name={value}

--- a/frontend/src/components/CreateCollectionModal/components/Content/components/LinkInput/style.ts
+++ b/frontend/src/components/CreateCollectionModal/components/Content/components/LinkInput/style.ts
@@ -1,6 +1,7 @@
 import { Button } from "@blueprintjs/core";
 import { PT_GRID_SIZE_PX } from "src/components/common/theme";
 import styled from "styled-components";
+import { StyledInput } from "../../style";
 
 export const Wrapper = styled.div`
   display: flex;
@@ -16,5 +17,13 @@ export const StyledButton = styled(Button)`
     position: absolute;
     top: 20px;
     right: -${PT_GRID_SIZE_PX}px;
+  }
+`;
+
+export const LinkWrapper = styled.div`
+  display: flex;
+
+  ${StyledInput}:not(:last-child) {
+    margin-right: ${2 * PT_GRID_SIZE_PX}px;
   }
 `;

--- a/frontend/src/components/CreateCollectionModal/components/Content/components/LinkInput/style.ts
+++ b/frontend/src/components/CreateCollectionModal/components/Content/components/LinkInput/style.ts
@@ -27,8 +27,12 @@ export const StyledLinkTypeButton = styled(Button)`
   justify-content: space-between;
 `;
 
-export const StyledURLInput = styled(Input)``;
-export const StyledNameInput = styled(Input)``;
+export const StyledURLInput = styled(Input)`
+  /* Blank for LinkWrapper to target */
+`;
+export const StyledNameInput = styled(Input)`
+  /* Blank for LinkWrapper to target */
+`;
 
 export const LinkWrapper = styled.div`
   display: flex;

--- a/frontend/src/components/CreateCollectionModal/components/Content/components/LinkInput/style.ts
+++ b/frontend/src/components/CreateCollectionModal/components/Content/components/LinkInput/style.ts
@@ -1,7 +1,7 @@
-import { Button } from "@blueprintjs/core";
+import { Button, Classes } from "@blueprintjs/core";
+import Input from "src/components/common/Form/Input";
 import { PT_GRID_SIZE_PX } from "src/components/common/theme";
 import styled from "styled-components";
-import { StyledInput } from "../../style";
 
 export const Wrapper = styled.div`
   display: flex;
@@ -20,10 +20,28 @@ export const StyledButton = styled(Button)`
   }
 `;
 
+export const StyledLinkTypeButton = styled(Button)`
+  width: 100%;
+  height: 34px;
+  margin-top: 4px;
+  justify-content: space-between;
+`;
+
+export const StyledURLInput = styled(Input)``;
+export const StyledNameInput = styled(Input)``;
+
 export const LinkWrapper = styled.div`
   display: flex;
 
-  ${StyledInput}:not(:last-child) {
+  & > * :not(:last-child) {
     margin-right: ${2 * PT_GRID_SIZE_PX}px;
+  }
+
+  & > .${Classes.POPOVER_WRAPPER} {
+    width: 25%;
+  }
+
+  & .${Classes.POPOVER_TARGET} {
+    width: 100%;
   }
 `;

--- a/frontend/src/components/CreateCollectionModal/components/Content/index.tsx
+++ b/frontend/src/components/CreateCollectionModal/components/Content/index.tsx
@@ -191,7 +191,7 @@ const Content: FC<Props> = (props) => {
             loading={isLoading}
             data-test-id="create-button"
           >
-            Create
+            {isEditCollection ? "Save" : "Create"}
           </Button>
         </div>
       </div>

--- a/frontend/src/components/CreateCollectionModal/components/Content/index.tsx
+++ b/frontend/src/components/CreateCollectionModal/components/Content/index.tsx
@@ -149,15 +149,17 @@ const Content: FC<Props> = (props) => {
               defaultValue={contact_email}
             />
           </ContactWrapper>
-          {links.map(({ type, id, url }, index) => (
+          {links.map(({ type, id, url, name, isValid }, index) => (
             <LinkInput
               index={index}
               type={type}
               id={id}
               key={id}
+              name={name}
               handleChange={handleLinkInputChange}
               handleDelete={handleLinkInputDelete}
               defaultValue={url}
+              isValid={isValid}
             />
           ))}
           <AddLink handleClick={handleAddLinkClick} Button={AddLinkButton} />
@@ -196,7 +198,7 @@ const Content: FC<Props> = (props) => {
     );
   }
 
-  async function submitCreateCollection() {
+  function createPayload() {
     if (!formEl?.current) return;
 
     const formData = new FormData(formEl.current);
@@ -212,6 +214,14 @@ const Content: FC<Props> = (props) => {
     payload.links = payloadLinks;
     payload[POLICY_PAYLOAD_KEY] = policyVersion;
 
+    return payload;
+  }
+
+  async function submitCreateCollection() {
+    const payload = createPayload();
+
+    if (!payload) return;
+
     setIsLoading(true);
 
     const collectionId = (await mutateCreateCollection(
@@ -224,20 +234,11 @@ const Content: FC<Props> = (props) => {
       router.push(ROUTES.PRIVATE_COLLECTION.replace(":id", collectionId));
     }
   }
+
   async function submitEditCollection() {
-    if (!formEl?.current) return;
+    const payload = createPayload();
 
-    const formData = new FormData(formEl.current);
-
-    const payload = formDataToObject(formData);
-
-    const payloadLinks = links.map(({ type, url }) => ({
-      link_type: type,
-      link_url: url,
-    }));
-
-    payload.links = payloadLinks;
-    payload[POLICY_PAYLOAD_KEY] = policyVersion;
+    if (!payload) return;
 
     setIsLoading(true);
 

--- a/frontend/src/components/CreateCollectionModal/components/Content/index.tsx
+++ b/frontend/src/components/CreateCollectionModal/components/Content/index.tsx
@@ -47,8 +47,8 @@ enum FIELD_NAMES {
 }
 
 const Content: FC<Props> = (props) => {
-  const { onClose, id } = props;
-  const initialBooleanState = id ? true : false;
+  const isEditCollection = !!props.id;
+  const initialBooleanState = isEditCollection;
   const [isValid, setIsValid] = useState(initialBooleanState);
   const [policyVersion, setPolicyVersion] = useState("");
   const [isLoading, setIsLoading] = useState(false);
@@ -68,7 +68,10 @@ const Content: FC<Props> = (props) => {
   const [mutateCreateCollection] = useCreateCollection();
   const [mutateEditCollection] = useEditCollection();
 
-  const { data } = useCollection({ id, visibility: VISIBILITY_TYPE.PRIVATE });
+  const { data } = useCollection({
+    id: props.id,
+    visibility: VISIBILITY_TYPE.PRIVATE,
+  });
   const { name, description, contact_email, contact_name } = data || {};
 
   const [links, setLinks] = useState<Link[]>(
@@ -96,6 +99,7 @@ const Content: FC<Props> = (props) => {
     }
   }, [links, fieldValidation, policyVersion, isValid]);
 
+  const { onClose } = props;
   return (
     <>
       <div className={Classes.DIALOG_BODY}>
@@ -171,7 +175,9 @@ const Content: FC<Props> = (props) => {
           <Button
             intent={Intent.PRIMARY}
             disabled={!isValid}
-            onClick={id ? submitEditCollection : submitCreateCollection}
+            onClick={
+              isEditCollection ? submitEditCollection : submitCreateCollection
+            }
             loading={isLoading}
             data-test-id="create-button"
           >
@@ -226,9 +232,13 @@ const Content: FC<Props> = (props) => {
 
     setIsLoading(true);
 
-    await mutateEditCollection(id, JSON.stringify(payload));
+    await mutateEditCollection({
+      id: props.id ?? "",
+      payload: JSON.stringify(payload),
+    });
 
     setIsLoading(false);
+    onClose();
   }
 
   function handleInputChange({ isValid: isValidFromInput, name }: Value) {

--- a/frontend/src/components/CreateCollectionModal/components/Content/index.tsx
+++ b/frontend/src/components/CreateCollectionModal/components/Content/index.tsx
@@ -82,9 +82,9 @@ const Content: FC<Props> = (props) => {
   const { name, description, contact_email, contact_name } = data || {};
 
   const [links, setLinks] = useState<Link[]>(
-    data?.links.map((link) => {
+    data?.links.map((link, index) => {
       return {
-        id: Date.now(),
+        id: Date.now() + index,
         isValid: true,
         linkName: link.link_name,
         linkType: link.link_type,

--- a/frontend/src/components/CreateCollectionModal/components/Content/index.tsx
+++ b/frontend/src/components/CreateCollectionModal/components/Content/index.tsx
@@ -35,9 +35,9 @@ interface Props {
 type Link = {
   id: number;
   url: string;
-  name: string;
+  linkName: string;
   isValid: boolean;
-  type: COLLECTION_LINK_TYPE;
+  linkType: COLLECTION_LINK_TYPE;
 };
 
 enum FIELD_NAMES {
@@ -82,12 +82,12 @@ const Content: FC<Props> = (props) => {
   const { name, description, contact_email, contact_name } = data || {};
 
   const [links, setLinks] = useState<Link[]>(
-    data?.links.map((link, index) => {
+    data?.links.map((link) => {
       return {
-        id: index,
+        id: Date.now(),
         isValid: true,
-        name: link.link_name,
-        type: link.link_type,
+        linkName: link.link_name,
+        linkType: link.link_type,
         url: link.link_url,
       };
     }) || []
@@ -149,16 +149,16 @@ const Content: FC<Props> = (props) => {
               defaultValue={contact_email}
             />
           </ContactWrapper>
-          {links.map(({ type, id, url, name, isValid }, index) => (
+          {links.map(({ linkType, id, url, linkName, isValid }, index) => (
             <LinkInput
               index={index}
-              type={type}
+              linkType={linkType}
               id={id}
               key={id}
-              name={name}
+              linkName={linkName}
               handleChange={handleLinkInputChange}
               handleDelete={handleLinkInputDelete}
-              defaultValue={url}
+              url={url}
               isValid={isValid}
             />
           ))}
@@ -205,9 +205,9 @@ const Content: FC<Props> = (props) => {
 
     const payload = formDataToObject(formData);
 
-    const payloadLinks = links.map(({ type, url, name }) => ({
+    const payloadLinks = links.map(({ linkType, url, linkName: name }) => ({
       link_name: name,
-      link_type: type,
+      link_type: linkType,
       link_url: url,
     }));
 
@@ -264,16 +264,18 @@ const Content: FC<Props> = (props) => {
 
   function handleLinkInputChange({
     index,
-    value,
+    url,
     isValid: isValidFromLinkInput,
-    name,
+    linkName,
+    linkType,
   }: LinkValue) {
     const link = links[index];
     const newLink: Link = {
       ...link,
       isValid: isValidFromLinkInput,
-      name,
-      url: value,
+      linkName,
+      linkType,
+      url,
     };
 
     const newLinks = [...links];
@@ -301,12 +303,12 @@ const Content: FC<Props> = (props) => {
   }
 };
 
-function createLinkInput(type: COLLECTION_LINK_TYPE) {
+function createLinkInput(linkType: COLLECTION_LINK_TYPE): Link {
   return {
     id: Date.now(),
     isValid: false,
-    name: "",
-    type,
+    linkName: "",
+    linkType,
     url: "",
   };
 }

--- a/frontend/src/components/CreateCollectionModal/components/Content/index.tsx
+++ b/frontend/src/components/CreateCollectionModal/components/Content/index.tsx
@@ -35,6 +35,7 @@ interface Props {
 type Link = {
   id: number;
   url: string;
+  name: string;
   isValid: boolean;
   type: COLLECTION_LINK_TYPE;
 };
@@ -45,6 +46,12 @@ enum FIELD_NAMES {
   CONTACT_NAME = "contact-name",
   CONTACT_EMAIL = "contact-email",
 }
+
+const AddLinkButton = () => (
+  <Button outlined intent={Intent.PRIMARY}>
+    Add Link
+  </Button>
+);
 
 const Content: FC<Props> = (props) => {
   const isEditCollection = !!props.id;
@@ -79,6 +86,7 @@ const Content: FC<Props> = (props) => {
       return {
         id: index,
         isValid: true,
+        name: link.link_name,
         type: link.link_type,
         url: link.link_url,
       };
@@ -152,7 +160,7 @@ const Content: FC<Props> = (props) => {
               defaultValue={url}
             />
           ))}
-          <AddLink handleClick={handleAddLinkClick} />
+          <AddLink handleClick={handleAddLinkClick} Button={AddLinkButton} />
           <Policy handleChange={handlePolicyChange} />
         </Form>
       </div>
@@ -195,7 +203,8 @@ const Content: FC<Props> = (props) => {
 
     const payload = formDataToObject(formData);
 
-    const payloadLinks = links.map(({ type, url }) => ({
+    const payloadLinks = links.map(({ type, url, name }) => ({
+      link_name: name,
       link_type: type,
       link_url: url,
     }));
@@ -256,11 +265,13 @@ const Content: FC<Props> = (props) => {
     index,
     value,
     isValid: isValidFromLinkInput,
+    name,
   }: LinkValue) {
     const link = links[index];
     const newLink: Link = {
       ...link,
       isValid: isValidFromLinkInput,
+      name,
       url: value,
     };
 
@@ -290,7 +301,13 @@ const Content: FC<Props> = (props) => {
 };
 
 function createLinkInput(type: COLLECTION_LINK_TYPE) {
-  return { id: Date.now(), isValid: false, type, url: "" };
+  return {
+    id: Date.now(),
+    isValid: false,
+    name: "",
+    type,
+    url: "",
+  };
 }
 
 export default Content;

--- a/frontend/src/components/CreateCollectionModal/index.tsx
+++ b/frontend/src/components/CreateCollectionModal/index.tsx
@@ -1,4 +1,4 @@
-import { Dialog } from "@blueprintjs/core";
+import { Dialog, IButtonProps } from "@blueprintjs/core";
 import loadable from "@loadable/component";
 import React, { FC, useState } from "react";
 import { QUERY_PARAMETERS } from "src/common/constants/queryParameters";
@@ -21,10 +21,15 @@ const AsyncCTA = loadable(
     /*webpackChunkName: 'CreateCollectionModalCTA' */ import("./components/CTA")
 );
 
-const CreateCollection: FC<{ className?: string; id?: Collection["id"] }> = ({
-  className,
-  id,
-}) => {
+const CreateCollectionButton = (props: Partial<IButtonProps>) => (
+  <StyledButton {...props}>Create Collection</StyledButton>
+);
+
+const CreateCollection: FC<{
+  className?: string;
+  id?: Collection["id"];
+  Button?: React.ElementType;
+}> = ({ className, id, Button }) => {
   const isAuth = get(FEATURES.AUTH) === BOOLEAN.TRUE;
   const urlParams = new URLSearchParams(window.location.search);
   const param = urlParams.get(QUERY_PARAMETERS.LOGIN_MODULE_REDIRECT);
@@ -52,15 +57,15 @@ const CreateCollection: FC<{ className?: string; id?: Collection["id"] }> = ({
         title: "Create an account or sign-in to get started",
       };
 
+  const OpenDialogButton = Button || CreateCollectionButton;
+
   return (
     <>
-      <StyledButton
+      <OpenDialogButton
         onMouseOver={() => config.content.preload()}
         onClick={toggleOpen}
         {...{ className }}
-      >
-        Create Collection
-      </StyledButton>
+      />
       <Dialog
         isCloseButtonShown={config.isCloseButtonShown}
         title={config.title}

--- a/frontend/src/components/CreateCollectionModal/index.tsx
+++ b/frontend/src/components/CreateCollectionModal/index.tsx
@@ -2,6 +2,7 @@ import { Dialog } from "@blueprintjs/core";
 import loadable from "@loadable/component";
 import React, { FC, useState } from "react";
 import { QUERY_PARAMETERS } from "src/common/constants/queryParameters";
+import { Collection } from "src/common/entities";
 import { get } from "src/common/featureFlags";
 import { FEATURES } from "src/common/featureFlags/features";
 import { BOOLEAN } from "src/common/localStorage/set";
@@ -20,7 +21,10 @@ const AsyncCTA = loadable(
     /*webpackChunkName: 'CreateCollectionModalCTA' */ import("./components/CTA")
 );
 
-const CreateCollection: FC<{ className?: string }> = ({ className }) => {
+const CreateCollection: FC<{ className?: string; id?: Collection["id"] }> = ({
+  className,
+  id,
+}) => {
   const isAuth = get(FEATURES.AUTH) === BOOLEAN.TRUE;
   const urlParams = new URLSearchParams(window.location.search);
   const param = urlParams.get(QUERY_PARAMETERS.LOGIN_MODULE_REDIRECT);
@@ -65,7 +69,7 @@ const CreateCollection: FC<{ className?: string }> = ({ className }) => {
         canEscapeKeyClose={config.canEscapeKeyClose}
         canOutsideClickClose={config.canOutsideClickClose}
       >
-        {isOpen && <config.content onClose={toggleOpen} />}
+        {isOpen && <config.content onClose={toggleOpen} id={id} />}
       </Dialog>
     </>
   );

--- a/frontend/src/components/common/Form/Input/index.tsx
+++ b/frontend/src/components/common/Form/Input/index.tsx
@@ -16,6 +16,7 @@ interface Props {
   noNameAttr?: boolean;
   className?: string;
   placeholder?: string;
+  defaultValue?: string;
 }
 
 const DangerIcon = () => {
@@ -32,6 +33,7 @@ const Input: FC<Props> = ({
   noNameAttr = false,
   className,
   placeholder = "",
+  defaultValue,
 }) => {
   const [isValid, setIsValid] = useState(true);
   const [errors, setErrors] = useState<string[]>([]);
@@ -57,6 +59,7 @@ const Input: FC<Props> = ({
           disabled={disabled}
           onChange={debounce(handleChange_, DEBOUNCE_TIME_MS)}
           placeholder={placeholder}
+          defaultValue={defaultValue}
         />
       </FormGroup>
     </StyledLabel>

--- a/frontend/src/components/common/Form/Input/style.ts
+++ b/frontend/src/components/common/Form/Input/style.ts
@@ -31,3 +31,8 @@ export const StyledInputGroup = styled(InputGroup)`
     border-radius: unset;
   }
 `;
+
+export const StyledDiv = styled.div`
+  display: flex;
+  flex-direction: column;
+`;

--- a/frontend/src/views/Collection/components/ActionButtons/components/MoreDropdown/components/Menu/index.tsx
+++ b/frontend/src/views/Collection/components/ActionButtons/components/MoreDropdown/components/Menu/index.tsx
@@ -7,8 +7,10 @@ import {
 import { IconNames } from "@blueprintjs/icons";
 import React from "react";
 import DeleteCollection from "src/components/Collections/components/DeleteCollection";
+import CreateCollection from "src/components/CreateCollectionModal";
+import styled from "styled-components";
 
-const DeleteButton = (props: IMenuItemProps) => {
+const DeleteButton = (props: Partial<IMenuItemProps>) => {
   return (
     <MenuItem
       {...props}
@@ -20,15 +22,37 @@ const DeleteButton = (props: IMenuItemProps) => {
   );
 };
 
+const EditButton = (props: Partial<IMenuItemProps>) => {
+  return (
+    <MenuItem
+      {...props}
+      shouldDismissPopover={false}
+      icon={IconNames.EDIT}
+      intent={Intent.NONE}
+      text="Edit Details"
+    />
+  );
+};
+
 interface Props {
   id?: string;
 }
 
+const StyledMenu = styled(RawMenu)`
+  border-radius: 3px;
+  padding: 8px;
+  & > li:last-child {
+    margin-bottom: 0;
+  }
+`;
+
 const Menu = ({ id = "" }: Props) => {
   return (
-    <RawMenu>
+    <StyledMenu>
       <DeleteCollection id={id} Button={DeleteButton} />
-    </RawMenu>
+      <EditButton />
+      <CreateCollection id={id} />
+    </StyledMenu>
   );
 };
 

--- a/frontend/src/views/Collection/components/ActionButtons/components/MoreDropdown/components/Menu/index.tsx
+++ b/frontend/src/views/Collection/components/ActionButtons/components/MoreDropdown/components/Menu/index.tsx
@@ -50,8 +50,7 @@ const Menu = ({ id = "" }: Props) => {
   return (
     <StyledMenu>
       <DeleteCollection id={id} Button={DeleteButton} />
-      <EditButton />
-      <CreateCollection id={id} />
+      <CreateCollection id={id} Button={EditButton} />
     </StyledMenu>
   );
 };

--- a/frontend/src/views/Collection/utils.tsx
+++ b/frontend/src/views/Collection/utils.tsx
@@ -40,7 +40,7 @@ export function renderLinks(links: Link[]) {
 
       if (!linkTypeOption) return null;
 
-      const urlName = name ? name : getUrlHost(url);
+      const urlName = name || getUrlHost(url);
 
       const { text } = linkTypeOption;
 

--- a/frontend/src/views/Collection/utils.tsx
+++ b/frontend/src/views/Collection/utils.tsx
@@ -34,24 +34,26 @@ export function renderLinks(links: Link[]) {
     }
   }
 
-  return orderedLinks.map(({ link_url: url, link_type: type }) => {
-    const linkTypeOption = COLLECTION_LINK_TYPE_OPTIONS[type];
+  return orderedLinks.map(
+    ({ link_url: url, link_type: type, link_name: name }) => {
+      const linkTypeOption = COLLECTION_LINK_TYPE_OPTIONS[type];
 
-    if (!linkTypeOption) return null;
+      if (!linkTypeOption) return null;
 
-    const urlHost = getUrlHost(url);
+      const urlName = name ? name : getUrlHost(url);
 
-    const { text } = linkTypeOption;
+      const { text } = linkTypeOption;
 
-    if (!urlHost) return null;
+      if (!urlName) return null;
 
-    return (
-      <React.Fragment key={`${type}+${url}`}>
-        <span className={Classes.TEXT_MUTED}>{text}</span>
-        <StyledLink href={url}>{urlHost}</StyledLink>
-      </React.Fragment>
-    );
-  });
+      return (
+        <React.Fragment key={`${type}+${url}`}>
+          <span className={Classes.TEXT_MUTED}>{text}</span>
+          <StyledLink href={url}>{urlName}</StyledLink>
+        </React.Fragment>
+      );
+    }
+  );
 }
 
 type LinkTypesToLinks = {

--- a/tests/unit/backend/chalice/api_server/test_v1_collection.py
+++ b/tests/unit/backend/chalice/api_server/test_v1_collection.py
@@ -689,3 +689,10 @@ class TestUpdateCollection(BaseAuthAPITest):
         response = self.app.put(f"/dp/v1/collections/{collection.id}", data=data, headers=headers)
         response.raise_for_status()
         self.assertEqual(links, json.loads(response.body)["links"])
+
+        # Clear All links
+        links = []
+        data = json.dumps({"links": links})
+        response = self.app.put(f"/dp/v1/collections/{collection.id}", data=data, headers=headers)
+        response.raise_for_status()
+        self.assertEqual(links, json.loads(response.body)["links"])


### PR DESCRIPTION
### Reviewers
**Functional:** @tihuan 

**Readability:** @MDunitz 

---

## Changes
- add
  - Mutation query to edit collections
- remove
- modify
  - Change LinkInput to allow for changing of link type and for adding a link name
  - Alter create collection modal content to allow for fetching collection information and prepopulating fields
  - Display link names on collection page

## Definition of Done (from ticket)
#952 
1. Navigate to a private collection
2. Click on edit
3. Update input fields
4. Click update
5. The collection page should now reflect the new changes

#955
- The MyCollections page will display the links in a collection using the link_name if present, otherwise the raw link will be shown.
-  Must also address Incorrect DOI format in Collection Dataset view. Closing the original issue and referencing here.

## QA steps (optional)

## Known Issues
#1102 
