### PR TITLE
Adding Script to delete datasets

### DIFF
--- a/backend/corpora/common/utils/db_session.py
+++ b/backend/corpora/common/utils/db_session.py
@@ -16,9 +16,10 @@ class DBSessionMaker:
     _session_make = None
     engine = None
 
-    def __init__(self):
+    def __init__(self, database_uri: str = None):
         if not self.engine:
-            self.engine = create_engine(CorporaDbConfig().database_uri, connect_args={"connect_timeout": 5})
+            database_uri = database_uri if database_uri else CorporaDbConfig().database_uri
+            self.engine = create_engine(database_uri, connect_args={"connect_timeout": 5})
         if not self._session_make:
             self._session_make = sessionmaker(bind=self.engine)
 

--- a/scripts/cxg_admin.py
+++ b/scripts/cxg_admin.py
@@ -53,10 +53,10 @@ def delete_dataset(ctx, uuid):
             dataset.delete()
             dataset = Dataset.get(session, uuid, include_tombstones=True)
             if dataset is None:
-                click.echo(f"Deleted: {uuid}")
+                click.echo(f"Deleted dataset:{uuid}")
                 exit(0)
             else:
-                click.echo(f"Failed to delete: {uuid}")
+                click.echo(f"Failed to delete dataset:{uuid}")
                 exit(1)
         else:
             click.echo(f"Dataset:{uuid} not found!")

--- a/scripts/delete_dataset.py
+++ b/scripts/delete_dataset.py
@@ -20,14 +20,12 @@ logging.basicConfig()
 logger = logging.getLogger(__name__)
 
 os.environ["CORPORA_LOCAL_DEV"] = "1"
-s3 = boto3.resource("s3")
 
 
 @click.command()
 @click.argument("uuid")
-@click.option(
-    "--deployment", default=os.getenv("DEPLOYMENT_STAGE", "test"), help="The name of the deployment to target."
-)
+@click.option("--deployment", default="test", show_default=True, help="The name of the deployment to target.")
+@click.confirmation_option(prompt="Are you sure you want to delete the dataset from cellxgene?")
 def delete_dataset(uuid, deployment):
     """Delete a dataset from Cellxgene. You must first SSH into the target deployment using `make db/tunnel` before
     running."""
@@ -55,7 +53,7 @@ def get_database_uri() -> str:
 
 
 def delete_deployment_directories(deployment_directories, deployment):
-    s3 = boto3.resource("s3")
+    s3 = boto3.resource("s3", endpoint_url=os.getenv("BOTO_ENDPOINT_URL"))
     bucket_name = f"hosted-cellxgene-{deployment}"
     bucket = s3.Bucket(bucket_name)
     for deployment_directory in deployment_directories:

--- a/scripts/delete_dataset.py
+++ b/scripts/delete_dataset.py
@@ -1,0 +1,28 @@
+#!/usr/bin/env python
+
+import os
+import sys
+
+import click
+
+pkg_root = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))  # noqa
+sys.path.insert(0, pkg_root)  # noqa
+
+from backend.corpora.common.utils.db_session import db_session_manager
+from backend.corpora.common.entities.dataset import Dataset
+
+
+@click.command()
+@click.argument('uuid')
+def delete_dataset(uuid):
+    """Delete a dataset from Cellxgene"""
+    click.echo(uuid)
+    with db_session_manager() as session:
+        dataset = Dataset.get(session, uuid)
+        print(dataset.to_dict())
+        # dataset.dataset_and_asset_deletion()
+        # dataset.delete()
+
+
+if __name__ == '__main__':
+    delete_dataset()

--- a/scripts/delete_dataset.py
+++ b/scripts/delete_dataset.py
@@ -1,28 +1,68 @@
 #!/usr/bin/env python
-
+import boto3
+import click
+import json
+import logging
 import os
 import sys
-
-import click
 
 pkg_root = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))  # noqa
 sys.path.insert(0, pkg_root)  # noqa
 
-from backend.corpora.common.utils.db_session import db_session_manager
+from backend.corpora.common.corpora_config import CorporaDbConfig
+from backend.corpora.common.utils.json import CustomJSONEncoder
+from backend.corpora.common.utils.db_session import db_session_manager, DBSessionMaker
 from backend.corpora.common.entities.dataset import Dataset
+
+from urllib.parse import urlparse
+
+logging.basicConfig()
+logger = logging.getLogger(__name__)
+
+os.environ["CORPORA_LOCAL_DEV"] = "1"
+s3 = boto3.resource("s3")
 
 
 @click.command()
-@click.argument('uuid')
-def delete_dataset(uuid):
-    """Delete a dataset from Cellxgene"""
-    click.echo(uuid)
+@click.argument("uuid")
+@click.option(
+    "--deployment", default=os.getenv("DEPLOYMENT_STAGE", "test"), help="The name of the deployment to target."
+)
+def delete_dataset(uuid, deployment):
+    """Delete a dataset from Cellxgene. You must first SSH into the target deployment using `make db/tunnel` before
+    running."""
+    DBSessionMaker(get_database_uri())
     with db_session_manager() as session:
-        dataset = Dataset.get(session, uuid)
-        print(dataset.to_dict())
-        # dataset.dataset_and_asset_deletion()
-        # dataset.delete()
+        dataset = Dataset.get(session, uuid, include_tombstones=True)
+        if dataset is not None:
+            print(json.dumps(dataset.to_dict(), sort_keys=True, indent=2, cls=CustomJSONEncoder))
+            delete_deployment_directories(dataset.deployment_directories, deployment)
+            dataset.dataset_and_asset_deletion()
+            dataset.delete()
+            dataset = Dataset.get(session, uuid, include_tombstones=True)
+        if dataset is None:
+            click.echo(f"Deleted: {uuid}")
+            exit(0)
+        else:
+            click.echo(f"Failed to delete: {uuid}")
+            exit(1)
 
 
-if __name__ == '__main__':
+def get_database_uri() -> str:
+    uri = urlparse(CorporaDbConfig().database_uri)
+    uri = uri._replace(netloc="@".join([uri[1].split("@")[0], "localhost:5432"]))
+    return uri.geturl()
+
+
+def delete_deployment_directories(deployment_directories, deployment):
+    s3 = boto3.resource("s3")
+    bucket_name = f"hosted-cellxgene-{deployment}"
+    bucket = s3.Bucket(bucket_name)
+    for deployment_directory in deployment_directories:
+        object_name = urlparse(deployment_directory.url).path.split("/", 2)[2]
+        logger.info(f"Deleting all files in bucket {bucket_name} under {object_name}.")
+        bucket.objects.filter(Prefix=object_name).delete()
+
+
+if __name__ == "__main__":
     delete_dataset()


### PR DESCRIPTION
### Reviewers
**Functional:** @mbarrien 

**Readability:** @seve 

---

## Changes
- Add script to delete a dataset from cellxgene. 
- Modify Database Session Engine to accept a databaser_uri as a parameter. This makes it easier to supply a database_uri to the ORM code.

## Definition of Done (from ticket)
- #1066
- Manually delete duplicate Lung dataset in Tabula Muris Senis
## QA steps (optional)
- Set DEPLOYMENT_STAGE, connect to the database using `make db/tunnel`. Run "script/delete_dataset.py"