### PR TITLE
thuang-feedback-1062

### DIFF
--- a/frontend/src/common/featureFlags/features.ts
+++ b/frontend/src/common/featureFlags/features.ts
@@ -4,3 +4,5 @@ export enum FEATURES {
   GENE_SETS = "gs",
   CURATOR = "rubber-chicken",
 }
+
+export const CURATOR_FEATURES = [FEATURES.CREATE_COLLECTION, FEATURES.AUTH];

--- a/frontend/src/common/featureFlags/features.ts
+++ b/frontend/src/common/featureFlags/features.ts
@@ -4,5 +4,3 @@ export enum FEATURES {
   GENE_SETS = "gs",
   CURATOR = "rubber-chicken",
 }
-
-export const CURATOR_FEATURES = [FEATURES.CREATE_COLLECTION, FEATURES.AUTH];

--- a/frontend/src/common/featureFlags/index.ts
+++ b/frontend/src/common/featureFlags/index.ts
@@ -1,9 +1,11 @@
 import { get as getLocalStorage } from "src/common/localStorage/get";
 import { BOOLEAN, set as setLocalStorage } from "src/common/localStorage/set";
 import { isSSR } from "../utils/isSSR";
-import { CURATOR_FEATURES, FEATURES } from "./features";
+import { FEATURES } from "./features";
 
 const FEATURE_FLAG_PREFIX = "cxg-ff-";
+
+const allowedKeys = Object.values(FEATURES) as string[];
 
 export function get(key: string): string | null {
   if (isSSR()) return null;
@@ -21,13 +23,9 @@ export function checkFeatureFlags(): void {
   const params = new URLSearchParams(search);
 
   params.forEach((value, key) => {
-    if (key === FEATURES.CURATOR) {
-      CURATOR_FEATURES.forEach((feature) => {
-        setFeatureFlag(feature, value);
-      });
-    } else {
-      setFeatureFlag(key, value);
-    }
+    if (!allowedKeys.includes(key)) return;
+
+    setFeatureFlag(key, value);
   });
 }
 

--- a/frontend/src/common/featureFlags/index.ts
+++ b/frontend/src/common/featureFlags/index.ts
@@ -1,29 +1,39 @@
 import { get as getLocalStorage } from "src/common/localStorage/get";
 import { BOOLEAN, set as setLocalStorage } from "src/common/localStorage/set";
 import { isSSR } from "../utils/isSSR";
-import { removeParams } from "../utils/removeParams";
-import { FEATURES } from "./features";
+import { CURATOR_FEATURES, FEATURES } from "./features";
 
 const FEATURE_FLAG_PREFIX = "cxg-ff-";
 
-// Checks both URL and localStorage
 export function get(key: string): string | null {
   if (isSSR()) return null;
 
-  const newlyAddedParams: Array<string> = [];
-  const params = new URLSearchParams(window.location.search);
-  if (window.location.search.indexOf("?") !== -1) {
-    Object.values(FEATURES).forEach((feature) => {
-      if (params.has(feature)) {
-        const URLValueAsBooleanString =
-          params.get(feature) === "true" ? BOOLEAN.TRUE : BOOLEAN.FALSE;
-        setLocalStorage(FEATURE_FLAG_PREFIX + feature, URLValueAsBooleanString);
-        newlyAddedParams.push(feature);
-      }
-    });
-  }
-
-  removeParams(newlyAddedParams);
-
   return getLocalStorage(FEATURE_FLAG_PREFIX + key);
+}
+
+export function checkFeatureFlags(): void {
+  if (isSSR()) return;
+
+  const search = window.location.search;
+
+  if (!search) return;
+
+  const params = new URLSearchParams(search);
+
+  params.forEach((value, key) => {
+    if (key === FEATURES.CURATOR) {
+      CURATOR_FEATURES.forEach((feature) => {
+        setFeatureFlag(feature, value);
+      });
+    } else {
+      setFeatureFlag(key, value);
+    }
+  });
+}
+
+function setFeatureFlag(key: string, value: string) {
+  const URLValueAsBooleanString =
+    value === "true" ? BOOLEAN.TRUE : BOOLEAN.FALSE;
+
+  setLocalStorage(FEATURE_FLAG_PREFIX + key, URLValueAsBooleanString);
 }

--- a/frontend/src/common/localStorage/set.ts
+++ b/frontend/src/common/localStorage/set.ts
@@ -3,7 +3,7 @@ export enum BOOLEAN {
   FALSE = "no",
 }
 
-export function set(key: string, value: BOOLEAN) {
+export function set(key: string, value: BOOLEAN): void {
   if (typeof window === "undefined") return;
 
   window?.localStorage?.setItem(key, value);

--- a/frontend/src/common/utils/removeParams.ts
+++ b/frontend/src/common/utils/removeParams.ts
@@ -1,15 +1,17 @@
 export function removeParams(params: Array<string> | string): void {
+  if (!params || !params.length) return;
+
   if (typeof params === "string") params = [params];
-  if (params.length < 1) return;
-  const urlParams = new URLSearchParams(window.location.search);
-  const url = window.location.href;
-  const afterSlashBeforeParam = url
-    .substring(url.indexOf("/") + 1)
-    .split("?")[0];
+
+  const { search, href } = window.location;
+
+  const urlParams = new URLSearchParams(search);
+  const pathname = new URL(href).pathname;
+
   params.forEach((param) => urlParams.delete(param));
-  let newURL = afterSlashBeforeParam;
-  if (urlParams.toString().length > 0) {
-    newURL += "?" + urlParams.toString();
-  }
-  window.history.replaceState(null, " ", "/" + newURL);
+
+  const query = urlParams.toString();
+  const newURL = pathname + (query ? "?" + query : "");
+
+  window.history.replaceState(null, "", newURL);
 }

--- a/frontend/src/components/CreateCollectionModal/components/CTA/index.tsx
+++ b/frontend/src/components/CreateCollectionModal/components/CTA/index.tsx
@@ -2,6 +2,7 @@ import { AnchorButton, Button, Classes, Intent } from "@blueprintjs/core";
 import React, { FC } from "react";
 import { API } from "src/common/API";
 import { QUERY_PARAMETERS } from "src/common/constants/queryParameters";
+import { BOOLEAN } from "src/common/localStorage/set";
 import { API_URL } from "src/configs/configs";
 import { ContentWrapper } from "./style";
 
@@ -28,7 +29,7 @@ const CTA: FC<Props> = ({ onClose }) => {
           </Button>
           <AnchorButton
             intent={Intent.PRIMARY}
-            href={`${API_URL}${API.LOG_IN}?redirect=?${QUERY_PARAMETERS.LOGIN_MODULE_REDIRECT}=true`}
+            href={`${API_URL}${API.LOG_IN}?redirect=?${QUERY_PARAMETERS.LOGIN_MODULE_REDIRECT}=${BOOLEAN.TRUE}`}
           >
             Continue
           </AnchorButton>

--- a/frontend/src/components/CreateCollectionModal/index.tsx
+++ b/frontend/src/components/CreateCollectionModal/index.tsx
@@ -40,7 +40,13 @@ const CreateCollection: FC<{
   const [isOpen, setIsOpen] = useState(shouldModuleOpen);
   const { data: userInfo, isLoading } = useUserInfo(isAuth);
 
-  if (get(FEATURES.CREATE_COLLECTION) !== BOOLEAN.TRUE || isLoading) {
+  // (thuang): FEATURES.CREATE_COLLECTION is being deprecated
+  const isCreateCollection = get(FEATURES.CREATE_COLLECTION) === BOOLEAN.TRUE;
+  const isCurator = get(FEATURES.CURATOR) === BOOLEAN.TRUE;
+
+  const shouldShowFeature = isCreateCollection || isCurator;
+
+  if (!shouldShowFeature || isLoading) {
     return null;
   }
 

--- a/frontend/src/components/CreateCollectionModal/index.tsx
+++ b/frontend/src/components/CreateCollectionModal/index.tsx
@@ -31,7 +31,6 @@ const CreateCollection: FC<{
   id?: Collection["id"];
   Button?: React.ElementType;
 }> = ({ className, id, Button }) => {
-  const isCurator = get(FEATURES.CURATOR) === BOOLEAN.TRUE;
   const isAuth = get(FEATURES.AUTH) === BOOLEAN.TRUE;
   const urlParams = new URLSearchParams(window.location.search);
   const param = urlParams.get(QUERY_PARAMETERS.LOGIN_MODULE_REDIRECT);
@@ -41,10 +40,7 @@ const CreateCollection: FC<{
   const [isOpen, setIsOpen] = useState(shouldModuleOpen);
   const { data: userInfo, isLoading } = useUserInfo(isAuth);
 
-  if (
-    (get(FEATURES.CREATE_COLLECTION) !== BOOLEAN.TRUE && !isCurator) ||
-    isLoading
-  ) {
+  if (get(FEATURES.CREATE_COLLECTION) !== BOOLEAN.TRUE || isLoading) {
     return null;
   }
 

--- a/frontend/src/components/Header/components/AuthButtons/index.tsx
+++ b/frontend/src/components/Header/components/AuthButtons/index.tsx
@@ -17,9 +17,7 @@ import { API_URL } from "src/configs/configs";
 import { ButtonWrapper, Initial } from "./style";
 
 const AuthButtons = () => {
-  const hasAuth =
-    get(FEATURES.AUTH) === BOOLEAN.TRUE ||
-    get(FEATURES.CURATOR) === BOOLEAN.TRUE;
+  const hasAuth = get(FEATURES.AUTH) === BOOLEAN.TRUE;
 
   const { data: userInfo, isLoading, error } = useUserInfo(hasAuth);
 

--- a/frontend/src/components/Header/components/AuthButtons/index.tsx
+++ b/frontend/src/components/Header/components/AuthButtons/index.tsx
@@ -17,7 +17,10 @@ import { API_URL } from "src/configs/configs";
 import { ButtonWrapper, Initial } from "./style";
 
 const AuthButtons = () => {
-  const hasAuth = get(FEATURES.AUTH) === BOOLEAN.TRUE;
+  // (thuang): FEATURES.AUTH is being deprecated
+  const hasAuth =
+    get(FEATURES.AUTH) === BOOLEAN.TRUE ||
+    get(FEATURES.CURATOR) === BOOLEAN.TRUE;
 
   const { data: userInfo, isLoading, error } = useUserInfo(hasAuth);
 

--- a/frontend/src/components/Header/index.tsx
+++ b/frontend/src/components/Header/index.tsx
@@ -11,12 +11,15 @@ import AuthButtons from "./components/AuthButtons";
 import { MainWrapper, MyCollectionsButton, Right, Wrapper } from "./style";
 
 const Header: FC = () => {
+  // (thuang): FEATURES.AUTH and FEATURES.CREATE_COLLECTION are being deprecated
   const isAuth = get(FEATURES.AUTH) === BOOLEAN.TRUE;
+  const isCurator = get(FEATURES.CURATOR) === BOOLEAN.TRUE;
+  const isCreateCollection = get(FEATURES.CREATE_COLLECTION) === BOOLEAN.TRUE;
 
-  const { data: userInfo } = useUserInfo(isAuth);
+  const { data: userInfo } = useUserInfo(isAuth || isCurator);
 
   const isMyCollectionsShown =
-    userInfo?.name && get(FEATURES.CREATE_COLLECTION) === BOOLEAN.TRUE;
+    userInfo?.name && (isCreateCollection || isCurator);
 
   return (
     <Wrapper>

--- a/frontend/src/components/Header/index.tsx
+++ b/frontend/src/components/Header/index.tsx
@@ -11,14 +11,12 @@ import AuthButtons from "./components/AuthButtons";
 import { MainWrapper, MyCollectionsButton, Right, Wrapper } from "./style";
 
 const Header: FC = () => {
-  const isCurator = get(FEATURES.CURATOR) === BOOLEAN.TRUE;
   const isAuth = get(FEATURES.AUTH) === BOOLEAN.TRUE;
 
-  const { data: userInfo } = useUserInfo(isAuth || isCurator);
+  const { data: userInfo } = useUserInfo(isAuth);
 
   const isMyCollectionsShown =
-    userInfo?.name &&
-    (get(FEATURES.CREATE_COLLECTION) === BOOLEAN.TRUE || isCurator);
+    userInfo?.name && get(FEATURES.CREATE_COLLECTION) === BOOLEAN.TRUE;
 
   return (
     <Wrapper>

--- a/frontend/src/pages/_app.tsx
+++ b/frontend/src/pages/_app.tsx
@@ -2,6 +2,7 @@ import { AppProps } from "next/app";
 import React from "react";
 import { QueryCache, ReactQueryCacheProvider } from "react-query";
 import { ReactQueryDevtools } from "react-query-devtools";
+import { checkFeatureFlags } from "src/common/featureFlags";
 import CookieBanner from "src/components/CookieBanner";
 import "src/global.scss";
 // (thuang): `layout.css` needs to be imported after `global.scss`
@@ -9,6 +10,8 @@ import "src/layout.css";
 import Layout from "../components/Layout";
 
 const queryCache = new QueryCache();
+
+checkFeatureFlags();
 
 function App({ Component, pageProps }: AppProps) {
   return (


### PR DESCRIPTION
### Reviewers
**Functional:** 
@seve 

**Readability:** 

---

## Changes
1. Update `removeParams()` function to use web API more
2. Add collection `CURATOR_FEATURES` to host all feature flags we want to enable for curators
3. Split featureFlags/index.ts to have getter and setter (`checkFeatureFlags()`)
4. Check for feature flags at app initiation time `checkFeatureFlags()` in `_app.tsx`. The setter will NOT set `rubber-chicken` to `true` in localStorage, so other feature flags remain the single source of truth. This is to prevent the weird state where in localStorage `cc=true` and `rubber-chicken=false`
5. Remove removing the feature flag params, since getter and setter are now separated

## Definition of Done (from ticket)
1. feature flags should work -- TESTED
2. Redirect after login should work -- NOT TESTED PLEASE HELP 😆 

## Known Issues
N/A