### PR TITLE
smoke-test add sleep to allow time for frontend to finish build

### DIFF
--- a/.github/workflows/push-tests.yml
+++ b/.github/workflows/push-tests.yml
@@ -68,6 +68,7 @@ jobs:
         run: |
           echo "DOCKER_REPO=${DOCKER_REPO}" > .env.ecr
           make local-sync
+          sleep 30  # Give frontend some time to finish building
           make local-smoke-test
       - name: Push images
         if: github.ref == 'refs/heads/main'


### PR DESCRIPTION
When running smoke tests, make local-sync starts up a temporary local frontend container from scratch. When the frontend container starts, it runs the npm build step, which takes some time to finish. Before this change, make local-smoke-test would start immediately, before the npm build step had finished, and the tests would fail since the server it is testing is not ready for testing.

This PR does a crude hack to wait 30 seconds after the local-sync, which has proven to be sufficient so far. If we want something a little bit faster, we could add a curl loop that checks a frontend health endpoint before continuing on (with appropriate timeout in case frontend build fails), but this seems to be unnecessary for now.