### PR TITLE
fix: deleting a dataset during a revision crashes collection page

### DIFF
--- a/backend/corpora/lambdas/api/v1/dataset.py
+++ b/backend/corpora/lambdas/api/v1/dataset.py
@@ -71,7 +71,7 @@ def delete_dataset(dataset_uuid: str, user: str):
         return make_response(jsonify("Can not delete a public dataset"), 405)
     if dataset.tombstone is False:
         if dataset.published:
-            dataset.tombstone_dataset_and_delete_child_objects()
+            dataset.update(tombstone=True)
         else:
             dataset.asset_deletion()
             dataset.deployment_directories_deletion()


### PR DESCRIPTION
### Reviewers
**Functional:** @MDunitz 

**Readability:** @seve 

---

## Changes
- modify deleting a published dataset in a revision to set the tombstone flag rather than delete the dataset children. This makes it easier for the frontend to track if the datasets have been deleted. It also avoids making refactoring changes to handle cases where the datasets do not have any assets or processing status.

## Definition of Done (from ticket)

## QA steps (optional)

## Known Issues
