### PR TITLE
fix: use a different database for testing corpora_orm

### DIFF
--- a/backend/corpora/common/utils/db_session.py
+++ b/backend/corpora/common/utils/db_session.py
@@ -18,13 +18,20 @@ class DBSessionMaker:
 
     def __init__(self, database_uri: str = None):
         if not self.engine:
-            database_uri = database_uri if database_uri else CorporaDbConfig().database_uri
-            self.engine = create_engine(database_uri, connect_args={"connect_timeout": 5})
+            self.database_uri = database_uri if database_uri else CorporaDbConfig().database_uri
+            self.engine = create_engine(self.database_uri, connect_args={"connect_timeout": 5})
         if not self._session_make:
             self._session_make = sessionmaker(bind=self.engine)
 
     def session(self, **kwargs) -> session.Session:
         return self._session_make(**kwargs)
+
+    @classmethod
+    def reset(cls):
+        cls._session_make = None
+        if cls.engine:
+            cls.engine.dispose()
+        cls.engine = None
 
 
 def clone(model: Base, primary_key: dict = None, **kwargs) -> Base:

--- a/backend/corpora/common/utils/db_session.py
+++ b/backend/corpora/common/utils/db_session.py
@@ -26,13 +26,6 @@ class DBSessionMaker:
     def session(self, **kwargs) -> session.Session:
         return self._session_make(**kwargs)
 
-    @classmethod
-    def reset(cls):
-        cls._session_make = None
-        if cls.engine:
-            cls.engine.dispose()
-        cls.engine = None
-
 
 def clone(model: Base, primary_key: dict = None, **kwargs) -> Base:
     """Clone an arbitrary sqlalchemy model object with new primary keys.

--- a/tests/unit/backend/corpora/common/test_corpora_orm.py
+++ b/tests/unit/backend/corpora/common/test_corpora_orm.py
@@ -50,22 +50,12 @@ class testToDict(DataPortalTestCase):
     @classmethod
     def setUpClass(cls):
         DataPortalTestCase.setUpClass()
-        session_maker = DBSessionMaker()
-        cls.database_name = __name__.split(".")[-1]
-        new_database_uri = f"{session_maker.database_uri}/{cls.database_name}"
-        session_maker.engine.execution_options(isolation_level="AUTOCOMMIT").execute(
-            f"CREATE DATABASE {cls.database_name}"
-        )
-        DBSessionMaker.reset()
-        engine = DBSessionMaker(new_database_uri).engine
+        engine = DBSessionMaker().engine
         Test_Base.metadata.drop_all(engine)
         Test_Base.metadata.create_all(engine)
 
     @classmethod
     def tearDownClass(cls):
-        DBSessionMaker.reset()
-        engine = DBSessionMaker().engine
-        engine.execution_options(isolation_level="AUTOCOMMIT").execute(f"DROP DATABASE IF EXISTS {cls.database_name}")
         cls.reinitialize_database()
         DataPortalTestCase.tearDownClass()
 

--- a/tests/unit/backend/corpora/common/test_corpora_orm.py
+++ b/tests/unit/backend/corpora/common/test_corpora_orm.py
@@ -1,12 +1,15 @@
 from sqlalchemy import Column, String, ForeignKey
+from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import relationship
 
-from backend.corpora.common.corpora_orm import Base
+from backend.corpora.common.corpora_orm import TransformingBase
 from backend.corpora.common.utils.db_session import DBSessionMaker, db_session_manager
 from tests.unit.backend.fixtures.data_portal_test_case import DataPortalTestCase
 
+Test_Base = declarative_base(cls=TransformingBase)
 
-class DbParent(Base):
+
+class DbParent(Test_Base):
     __tablename__ = "parent"
 
     name = Column(String)
@@ -15,7 +18,7 @@ class DbParent(Base):
     properties = relationship("DbProperty", back_populates="parent")
 
 
-class DbChild(Base):
+class DbChild(Test_Base):
     __tablename__ = "child"
 
     name = Column(String)
@@ -24,7 +27,7 @@ class DbChild(Base):
     properties = relationship("DbProperty", secondary="associate_property_owner", back_populates="children")
 
 
-class DbProperty(Base):
+class DbProperty(Test_Base):
     __tablename__ = "property"
     name = Column(String)
     children = relationship("DbChild", secondary="associate_property_owner", back_populates="properties")
@@ -32,7 +35,7 @@ class DbProperty(Base):
     parent = relationship("DbParent", uselist=False, back_populates="properties")
 
 
-class AssociatePropertyOwner(Base):
+class AssociatePropertyOwner(Test_Base):
     __tablename__ = "associate_property_owner"
     child_id = Column(String, ForeignKey("child.id"), index=True)
     property_id = Column(String, ForeignKey("property.id"), index=True)
@@ -47,12 +50,22 @@ class testToDict(DataPortalTestCase):
     @classmethod
     def setUpClass(cls):
         DataPortalTestCase.setUpClass()
-        engine = DBSessionMaker().engine
-        Base.metadata.drop_all(engine)
-        Base.metadata.create_all(engine)
+        session_maker = DBSessionMaker()
+        cls.database_name = __name__.split(".")[-1]
+        new_database_uri = f"{session_maker.database_uri}/{cls.database_name}"
+        session_maker.engine.execution_options(isolation_level="AUTOCOMMIT").execute(
+            f"CREATE DATABASE {cls.database_name}"
+        )
+        DBSessionMaker.reset()
+        engine = DBSessionMaker(new_database_uri).engine
+        Test_Base.metadata.drop_all(engine)
+        Test_Base.metadata.create_all(engine)
 
     @classmethod
     def tearDownClass(cls):
+        DBSessionMaker.reset()
+        engine = DBSessionMaker().engine
+        engine.execution_options(isolation_level="AUTOCOMMIT").execute(f"DROP DATABASE IF EXISTS {cls.database_name}")
         cls.reinitialize_database()
         DataPortalTestCase.tearDownClass()
 


### PR DESCRIPTION
### Reviewers
**Functional:** @MDunitz 

---
Before we were using the same SQLAlchemy Base for corpora_orm and the tests. This cause tests tabled to be added to the staging and production databases. To fix this, the tests now create their own database and use their own SQLAlchmey base when running the tests. The database and data are cleaned up after the test.

## Changes
- add Test_Base to avoid confusion with corpora_orm.Base 
- add DBSessionMaker.reset to reset the DBSessionMaker
- Create a new database to run corpora_orm tests on.

## Definition of Done (from ticket)
- related to #1214. It prevents the tables from being created in the future.
- 
## QA steps (optional)

## Known Issues
