### PR TITLE
fix: type inferencing

### DIFF
--- a/.github/workflows/standup-assignment-notification.yml
+++ b/.github/workflows/standup-assignment-notification.yml
@@ -15,7 +15,8 @@ jobs:
           SEVE="@seve"
           MADISON="@madison.dunitz"
           TRENT="@trent.smith"
-          ENGINEERS=($SEVE $MADISON $TRENT)
+          TIMMY="@thuang"
+          ENGINEERS=($SEVE $MADISON $TIMMY)
           ENGINEER_COUNT=${#ENGINEERS[@]}
           SLACK_MESSAGE="Standup this week!\n"
           i=0

--- a/backend/corpora/common/utils/cxg_generation_utils.py
+++ b/backend/corpora/common/utils/cxg_generation_utils.py
@@ -5,7 +5,7 @@ import tiledb
 
 from backend.corpora.common.utils.type_conversion_utils import (
     get_encoding_dtype_of_array,
-    get_dtype_and_schema_of_array
+    get_dtype_and_schema_of_array,
 )
 
 

--- a/backend/corpora/common/utils/cxg_generation_utils.py
+++ b/backend/corpora/common/utils/cxg_generation_utils.py
@@ -3,7 +3,10 @@ import json
 import numpy as np
 import tiledb
 
-from backend.corpora.common.utils.type_conversion_utils import get_encoding_dtype_of_array, get_dtype_and_schema_of_array
+from backend.corpora.common.utils.type_conversion_utils import (
+    get_encoding_dtype_of_array,
+    get_dtype_and_schema_of_array
+)
 
 
 def convert_dictionary_to_cxg_group(cxg_container, metadata_dict, group_metadata_name="cxg_group_metadata"):

--- a/backend/corpora/common/utils/cxg_generation_utils.py
+++ b/backend/corpora/common/utils/cxg_generation_utils.py
@@ -3,7 +3,7 @@ import json
 import numpy as np
 import tiledb
 
-from backend.corpora.common.utils.type_conversion_utils import get_dtype_of_array, get_dtype_and_schema_of_array
+from backend.corpora.common.utils.type_conversion_utils import get_encoding_dtype_of_array, get_dtype_and_schema_of_array
 
 
 def convert_dictionary_to_cxg_group(cxg_container, metadata_dict, group_metadata_name="cxg_group_metadata"):
@@ -47,7 +47,7 @@ def convert_dataframe_to_cxg_array(cxg_container, dataframe_name, dataframe, ind
             ]
         )
         attrs = [
-            tiledb.Attr(name=column, dtype=get_dtype_of_array(dataframe[column]), filters=tiledb_filter)
+            tiledb.Attr(name=column, dtype=get_encoding_dtype_of_array(dataframe[column]), filters=tiledb_filter)
             for column in dataframe
         ]
         domain = tiledb.Domain(

--- a/backend/corpora/common/utils/type_conversion_utils.py
+++ b/backend/corpora/common/utils/type_conversion_utils.py
@@ -170,8 +170,8 @@ def _can_cast_array_values_to_int32(array: Union[np.ndarray, pd.Series, pd.Index
     if array.size == 0:
         return True
 
-    ii = np.iinfo(np.int32)
-    if array.min() >= ii.min and array.max() <= ii.max:
+    int32_machine_limits = np.iinfo(np.int32)
+    if array.min() >= int32_machine_limits.min and array.max() <= int32_machine_limits.max:
         return True
 
     return False

--- a/backend/corpora/common/utils/type_conversion_utils.py
+++ b/backend/corpora/common/utils/type_conversion_utils.py
@@ -5,7 +5,7 @@ import numpy as np
 import pandas as pd
 
 """
-These routines drive all type inference for the schema generation and the 
+These routines drive all type inference for the schema generation and the
 FBS (REST OTA) encoding. They are also used for CXG generation.
 
 

--- a/backend/corpora/common/utils/type_conversion_utils.py
+++ b/backend/corpora/common/utils/type_conversion_utils.py
@@ -14,7 +14,7 @@ H5AD Type                       REST              REST
 ----------------------------    --------------    ---------------   ----------------------
 bool_/bool                      uint8             boolean
 (u)int8, (u)int16, int32        int32             int32
-uint32, (u)it64                 int32             int32             CHECKS value bounds
+uint32, (u)iit64                int32             int32             CHECKS value bounds
 float16, float32, float64       float32           float32[0]
 
 categorical[T is numeric[4]]:

--- a/backend/corpora/common/utils/type_conversion_utils.py
+++ b/backend/corpora/common/utils/type_conversion_utils.py
@@ -14,7 +14,7 @@ H5AD Type                       REST              REST
 ----------------------------    --------------    ---------------   ----------------------
 bool_/bool                      uint8             boolean
 (u)int8, (u)int16, int32        int32             int32
-uint32, (u)iit64                int32             int32             CHECKS value bounds
+uint32, (u)int64                int32             int32             CHECKS value bounds
 float16, float32, float64       float32           float32[0]
 
 categorical[T is numeric[4]]:
@@ -51,15 +51,15 @@ def get_dtypes_and_schemas_of_dataframe(dataframe: pd.DataFrame):
     return dtypes_by_column_name, schema_type_hints_by_column_name
 
 
-def get_encoding_dtype_of_array(array: Union[np.ndarray, pd.Series]) -> np.dtype:
+def get_encoding_dtype_of_array(array: Union[np.ndarray, pd.Series, pd.Index]) -> np.dtype:
     return _get_type_info(array)[0]
 
 
-def get_schema_type_hint_of_array(array: Union[np.ndarray, pd.Series]) -> dict:
+def get_schema_type_hint_of_array(array: Union[np.ndarray, pd.Series, pd.Index]) -> dict:
     return _get_type_info(array)[1]
 
 
-def get_dtype_and_schema_of_array(array: Union[np.ndarray, pd.Series]) -> Tuple[np.dtype, dict]:
+def get_dtype_and_schema_of_array(array: Union[np.ndarray, pd.Series, pd.Index]) -> Tuple[np.dtype, dict]:
     """Return tuple (encoding_dtype, schema_type_hint)"""
     return _get_type_info(array)
 
@@ -76,6 +76,10 @@ def _get_type_info_from_dtype(dtype) -> Union[Tuple[np.dtype, dict], None]:
     """
     Best-effort to determine encoding type and schema hint from a dtype.
     If this is not possible, or the type is unsupported, return None.
+
+    This should be a subset of the cases which are supported by
+    _get_type_info().  The latter should be preferred if the array (values)
+    are available for typing.
     """
     if dtype.kind == "b":
         return (np.uint8, {"type": "boolean"})
@@ -88,13 +92,16 @@ def _get_type_info_from_dtype(dtype) -> Union[Tuple[np.dtype, dict], None]:
             return (np.int32, {"type": "int32"})
 
     if dtype.kind == "f":
-        if np.can_cast(dtype, np.float32):
-            return (np.float32, {"type": "float32"})
+        _float64_warning(dtype)
+        return (np.float32, {"type": "float32"})
+
+    if dtype.kind == "O" and not dtype.name == "category":
+        return (np.dtype(str), {"type": "string"})
 
     return None
 
 
-def _get_type_info(array: Union[np.ndarray, pd.Series]) -> Tuple[np.dtype, dict]:
+def _get_type_info(array: Union[np.ndarray, pd.Series, pd.Index]) -> Tuple[np.dtype, dict]:
     """
     Determine encoding type and schema hint from an array.  This allows more
     flexible casting than may be possible by using just the dtype, as it can
@@ -131,54 +138,43 @@ def _get_type_info(array: Union[np.ndarray, pd.Series]) -> Tuple[np.dtype, dict]
         # all other extension types are str-encoded
         return (np.dtype(str), {"type": "string"})
 
-    if dtype.kind in ["i", "u"] and can_cast_to_int(array, np.int32):
+    if dtype.kind in ["i", "u"] and _can_cast_array_values_to_int32(array):
         return (np.int32, {"type": "int32"})
 
-    if dtype.kind == "f" and can_cast_to_float32(array):
+    if dtype.kind == "f":
+        _float64_warning(array.dtype)
         return (np.float32, {"type": "float32"})
 
     raise TypeError(f"Annotations of type {dtype} are unsupported.")
 
 
-def can_cast_to_float32(array: Union[np.ndarray, pd.Series]) -> bool:
+def _float64_warning(dtype):
     """
-    Returns True if the underlying type is float, of any width.
-    Else, returns False
+    Warn the user if we are down-casting a float64 to float32, and may potentially lose information.
     """
-    # Accept any float as long as magnitude can still be represented.
-    if array.dtype.kind == "f":
-        if not np.can_cast(array.dtype, np.float32):
-            logging.warning(f"Type {array.dtype.name} will be converted to 32 bit float and may lose precision.")
+    if dtype.kind == "f" and not np.can_cast(dtype, np.float32):
+        logging.warning(f"Type {dtype.name} will be converted to 32 bit float and may lose precision.")
+
+
+def _can_cast_array_values_to_int32(array: Union[np.ndarray, pd.Series, pd.Index]) -> bool:
+    """
+    Return true if the (U)INT array values can be safely cast to int32.  We allow size reducing
+    casts (ie, int64 to int32) if no actual values require the larger size (ie, actual values
+    can be represented by the smaller type).
+    """
+    assert array.dtype.kind in ["u", "i"]
+
+    if np.can_cast(array.dtype, np.int32):
+        return True
+
+    if array.size == 0:
+        return True
+
+    ii = np.iinfo(np.int32)
+    if array.min() >= ii.min and array.max() <= ii.max:
         return True
 
     return False
-
-
-def can_cast_to_int(array: Union[np.ndarray, pd.Series], target: np.dtype) -> bool:
-    """
-    Return true if the dtype can be safely cast to int dtype.  We allow size reducing casts
-    (ie, int64 to int32) if no actual values require the larger size (ie, actual values
-    can be represented by the smaller type).
-    """
-    if array.dtype.kind in ["u", "i"]:
-        if np.can_cast(array.dtype, target):
-            return True
-
-        if array.size == 0:
-            return True
-
-        ii = np.iinfo(target)
-        if array.min() >= ii.min and array.max() <= ii.max:
-            return True
-
-    return False
-
-
-def convert_pandas_series_to_numpy(series_to_convert: pd.Series, dtype):
-    if series_to_convert.hasnans and dtype == np.int32:
-        logging.error("Cannot convert a pandas Series object to an integer dtype if it contains NA values.")
-
-    return series_to_convert.to_numpy(dtype)
 
 
 def convert_string_to_value(value: str):

--- a/backend/corpora/common/utils/type_conversion_utils.py
+++ b/backend/corpora/common/utils/type_conversion_utils.py
@@ -1,7 +1,41 @@
+from typing import Union, Tuple
 import logging
 
 import numpy as np
 import pandas as pd
+
+"""
+These routines drive all type inference for the schema generation and the 
+FBS (REST OTA) encoding. They are also used for CXG generation.
+
+
+H5AD Type                       REST              REST
+(ndarray, Series, Index)        FBS encoding      schema type       ERROR/exceptions
+----------------------------    --------------    ---------------   ----------------------
+bool_/bool                      uint8             boolean
+(u)int8, (u)int16, int32        int32             int32
+uint32, (u)it64                 int32             int32             CHECKS value bounds
+float16, float32, float64       float32           float32[0]
+
+categorical[T is numeric[4]]:
+    hasna = False               T                 categorical[1]
+    hasna = True                float32           categorical[1]    CHECKS value bounds
+
+categorical[T not numeric]      JSON/str          categorical[1,2]
+
+(other object)                  JSON/str          string
+
+(all other)                                                         Always an ERROR[3]
+
+
+Notes:
+[0] IEEE format, includes non-finite numbers (NaN, Inf, ...)
+[1] with NO categories enumerated (client side does it to handle rounding)
+[2] NA (undefined) categories are assigned a JSON null value
+[3] Includes all other numpy types:  datetime, complex, etc.
+[4] means float, int, uint (dtype.kind in ['i','u','f'])
+
+"""
 
 
 def get_dtypes_and_schemas_of_dataframe(dataframe: pd.DataFrame):
@@ -17,129 +51,132 @@ def get_dtypes_and_schemas_of_dataframe(dataframe: pd.DataFrame):
     return dtypes_by_column_name, schema_type_hints_by_column_name
 
 
-def get_dtype_of_array(array: pd.Series):
-    return get_dtype_and_schema_of_array(array)[0]
+def get_encoding_dtype_of_array(array: Union[np.ndarray, pd.Series]) -> np.dtype:
+    return _get_type_info(array)[0]
 
 
-def get_schema_type_hint_of_array(array: pd.Series):
-    return get_dtype_and_schema_of_array(array)[1]
+def get_schema_type_hint_of_array(array: Union[np.ndarray, pd.Series]) -> dict:
+    return _get_type_info(array)[1]
 
 
-def get_dtype_and_schema_of_array(array: pd.Series):
-    return (
-        get_dtype_from_dtype(array.dtype, array_values=array),
-        get_schema_type_hint_from_dtype(array.dtype, array_values=array),
-    )
+def get_dtype_and_schema_of_array(array: Union[np.ndarray, pd.Series]) -> Tuple[np.dtype, dict]:
+    """Return tuple (encoding_dtype, schema_type_hint)"""
+    return _get_type_info(array)
 
 
-def get_dtype_from_dtype(dtype, array_values=None):
+def get_schema_type_hint_from_dtype(dtype) -> dict:
+    res = _get_type_info_from_dtype(dtype)
+    if res is None:
+        raise TypeError(f"Annotations of type {dtype} are unsupported.")
+    else:
+        return res[1]
+
+
+def _get_type_info_from_dtype(dtype) -> Union[Tuple[np.dtype, dict], None]:
     """
-    Given a data type, finds the equivalent data type that the array should be encoded as. Notably, this is relevant
-    for 64 bit values which will get downcast to 32 bit.
+    Best-effort to determine encoding type and schema hint from a dtype.
+    If this is not possible, or the type is unsupported, return None.
     """
+    if dtype.kind == "b":
+        return (np.uint8, {"type": "boolean"})
 
-    dtype_name = dtype.name
-    dtype_kind = dtype.kind
+    if dtype.kind == "U":
+        return (np.dtype(str), {"type": "string"})
 
-    if dtype_name == "bool":
-        return np.uint8
-    if dtype_name == "object" and dtype_kind == "O":
-        return str
-    if dtype_name == "category":
-        return get_dtype_from_dtype(dtype.categories.dtype, array_values)
-
-    if can_cast_to_int32(dtype, array_values):
-        return np.int32
-    if can_cast_to_float32(dtype, array_values):
-        return np.float32
-    if not can_cast_to_float32(dtype, array_values):
-        return np.float64
-
-    raise TypeError(f"Annotations of type {dtype} are unsupported.")
-
-
-def get_schema_type_hint_from_dtype(dtype, array_values=None):
-    """
-    Returns a dictionary that contains type hints about the data type given, especially if the data type is 64 bit
-    and will be downcast to 32 bit.
-    """
-
-    dtype_name = dtype.name
-    dtype_kind = dtype.kind
-
-    if dtype == np.float32 or dtype == np.int32:
-        return {"type": dtype_name}
-    if dtype_name == "bool":
-        return {"type": "boolean"}
-    if dtype_name == "object" and dtype_kind == "O":
-        return {"type": "string"}
-    if dtype_name == "category":
-        return {"type": "categorical", "categories": dtype.categories.tolist()}
-
-    if can_cast_to_int32(dtype, array_values):
-        return {"type": "int32"}
-    if can_cast_to_float32(dtype, array_values):
-        return {"type": "float32"}
-    if dtype_kind == "f" and not can_cast_to_float32(dtype, array_values):
-        return {"type": "float64"}
-
-    raise TypeError(f"Annotations of type {dtype} are unsupported.")
-
-
-def can_cast_to_float32(dtype, array_values):
-    """
-    Optimistically returns True signifying that a type downcast to float32 is possible whenever the incoming type is
-    a float.
-
-    We also handle a special case here where the array is a Series object with integer categorical values AND NaNs.
-    Since NaNs are floating points in numpy, we upcast the integer array to float32 and return True.
-    """
+    if dtype.kind in ["i", "u"]:
+        if np.can_cast(dtype, np.int32):
+            return (np.int32, {"type": "int32"})
 
     if dtype.kind == "f":
-        if not np.can_cast(dtype, np.float32):
-            logging.warning(f"Type {dtype.name} will be converted to 32 bit float and may lose precision.")
+        if np.can_cast(dtype, np.float32):
+            return (np.float32, {"type": "float32"})
 
-        return True
+    return None
 
-    if dtype.kind == "O" and array_values.hasnans:
+
+def _get_type_info(array: Union[np.ndarray, pd.Series]) -> Tuple[np.dtype, dict]:
+    """
+    Determine encoding type and schema hint from an array.  This allows more
+    flexible casting than may be possible by using just the dtype, as it can
+    account for category types and array values.
+    """
+    if (
+        not isinstance(array, np.ndarray)
+        and not isinstance(array, pd.Series)
+        and not isinstance(array, pd.Index)
+        and not hasattr(array, "dtype")
+    ):
+        raise TypeError("Unsupported data type.")
+
+    dtype = array.dtype
+
+    res = _get_type_info_from_dtype(dtype)
+    if res is not None:
+        return res
+
+    if dtype.kind == "O":
+        if dtype.name == "category":
+            # Sometimes CategoricalDType can be encoded as int or float without further fuss.
+            # Do not specify the categories in the schema - let the client-side figure it out
+            # on its own.  Utilize Series.to_numpy() to do casting that handles categorical
+            # NA/NaN (missing or undefined) categories.
+            if dtype.categories.dtype.kind in ["f", "i", "u"]:
+                return (
+                    _get_type_info(array.to_numpy())[0],
+                    {"type": "categorical"},
+                )
+            else:
+                return (np.dtype(str), {"type": "categorical", "categories": dtype.categories.to_list()})
+
+        # all other extension types are str-encoded
+        return (np.dtype(str), {"type": "string"})
+
+    if dtype.kind in ["i", "u"] and can_cast_to_int(array, np.int32):
+        return (np.int32, {"type": "int32"})
+
+    if dtype.kind == "f" and can_cast_to_float32(array):
+        return (np.float32, {"type": "float32"})
+
+    raise TypeError(f"Annotations of type {dtype} are unsupported.")
+
+
+def can_cast_to_float32(array: Union[np.ndarray, pd.Series]) -> bool:
+    """
+    Returns True if the underlying type is float, of any width.
+    Else, returns False
+    """
+    # Accept any float as long as magnitude can still be represented.
+    if array.dtype.kind == "f":
+        if not np.can_cast(array.dtype, np.float32):
+            logging.warning(f"Type {array.dtype.name} will be converted to 32 bit float and may lose precision.")
         return True
 
     return False
 
 
-def can_cast_to_int32(dtype, array_values=None):
+def can_cast_to_int(array: Union[np.ndarray, pd.Series], target: np.dtype) -> bool:
     """
-    A type can be cast to 32 bit, overriding the numpy `cast_cast` function if the values in the array that are of
-    the higher precision type has values that are entirely within the range of the downcast type.
+    Return true if the dtype can be safely cast to int dtype.  We allow size reducing casts
+    (ie, int64 to int32) if no actual values require the larger size (ie, actual values
+    can be represented by the smaller type).
     """
-
-    # Since a NaN is technically a float, any array that contains NaNs cannot be cast to an integer so immediately
-    # return False.
-    if array_values.hasnans:
-        return False
-
-    # If the array is categorical, then we need to order the array values so that functions min and max that occur
-    # later, can function. They do not function on unordered categories.
-    ordered_array_values = array_values
-    if array_values.dtype.name == "category" and not array_values.cat.ordered:
-        ordered_array_values = array_values.cat.as_ordered()
-
-    if dtype.kind in ["i", "u"]:
-        if np.can_cast(dtype, np.int32):
+    if array.dtype.kind in ["u", "i"]:
+        if np.can_cast(array.dtype, target):
             return True
-        ii32 = np.iinfo(np.int32)
-        if (
-            not ordered_array_values.empty
-            and (ordered_array_values.min() >= ii32.min and ordered_array_values.max() <= ii32.max)
-            or ordered_array_values.empty
-        ):
+
+        if array.size == 0:
             return True
+
+        ii = np.iinfo(target)
+        if array.min() >= ii.min and array.max() <= ii.max:
+            return True
+
     return False
 
 
 def convert_pandas_series_to_numpy(series_to_convert: pd.Series, dtype):
     if series_to_convert.hasnans and dtype == np.int32:
-        logging.error("Cannot convert a pandas Series object to an integer dtype if it contains NaNs.")
+        logging.error("Cannot convert a pandas Series object to an integer dtype if it contains NA values.")
 
     return series_to_convert.to_numpy(dtype)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,3 +21,4 @@ tiledb<0.9
 click==7.1.2
 -r ./backend/corpora/api_server/requirements.txt
 rsa>=4.7 # not directly required, pinned by Snyk to avoid a vulnerability
+parameterized

--- a/tests/unit/backend/corpora/common/utils/test_type_conversion_utils.py
+++ b/tests/unit/backend/corpora/common/utils/test_type_conversion_utils.py
@@ -1,7 +1,5 @@
 import unittest
 import logging
-from time import time
-from unittest.mock import patch
 from parameterized import parameterized_class
 
 import numpy as np

--- a/tests/unit/backend/corpora/common/utils/test_type_conversion_utils.py
+++ b/tests/unit/backend/corpora/common/utils/test_type_conversion_utils.py
@@ -10,174 +10,15 @@ from pandas import Series, DataFrame
 from scipy import sparse
 
 from backend.corpora.common.utils.type_conversion_utils import (
-    can_cast_to_float32,
-    can_cast_to_int,
     get_encoding_dtype_of_array,
     get_schema_type_hint_of_array,
     get_dtypes_and_schemas_of_dataframe,
     get_dtype_and_schema_of_array,
-    convert_pandas_series_to_numpy,
+    get_schema_type_hint_from_dtype,
 )
 
 
 class TestTypeConversionUtils(unittest.TestCase):
-    def test__can_cast_to_float32__string_is_false(self):
-        array_to_convert = Series(data=["1", "2", "3"], dtype=str)
-
-        can_cast = can_cast_to_float32(array_to_convert)
-
-        self.assertFalse(can_cast)
-
-    def test__can_cast_to_float32__float64_is_true_warning_outputted(self):
-        array_to_convert = Series(data=[1, 2, 3], dtype=np.dtype(np.float64))
-
-        with self.assertLogs(level="WARN") as logger:
-            can_cast = can_cast_to_float32(array_to_convert)
-            self.assertIn("may lose precision", logger.output[0])
-
-        self.assertTrue(can_cast)
-
-    @patch("logging.warning")
-    def test__can_cast_to_float32__float32_is_false(self, mock_log_warning):
-        array_to_convert = Series(data=[1, 2, 3], dtype=np.dtype(np.float32))
-
-        can_cast = can_cast_to_float32(array_to_convert)
-
-        self.assertTrue(can_cast)
-        assert not mock_log_warning.called
-
-    def test__can_cast_to_float32__categorical_float64_is_false(self):
-        array_to_convert = Series(data=[1.1, 2.2, 3.3], dtype="category")
-
-        can_cast = can_cast_to_float32(array_to_convert)
-
-        self.assertFalse(can_cast)
-
-    def test__can_cast_to_float32__categorical_int64_with_nans_is_true(self):
-        array_to_convert = Series(data=[1, 2, np.NaN], dtype="category")
-        self.assertFalse(can_cast_to_float32(array_to_convert))
-        self.assertTrue(can_cast_to_float32(array_to_convert.to_numpy()))
-
-    def test__can_cast_to_float_32__float_32_with_nans_is_true(self):
-        array_to_convert = Series(data=[1, 2, np.NaN], dtype=np.dtype(np.float32))
-
-        can_cast = can_cast_to_float32(array_to_convert)
-
-        self.assertTrue(can_cast)
-
-    def test__can_cast_to_int32__string_is_false(self):
-        array_to_convert = Series(data=["1", "2", "3"], dtype=str)
-
-        can_cast = can_cast_to_int(array_to_convert, np.int32)
-
-        self.assertFalse(can_cast)
-
-    def test__can_cast_to_int32__int64_is_true(self):
-        array_to_convert = Series(data=[1, 2, 3], dtype=np.dtype(np.int64))
-
-        can_cast = can_cast_to_int(array_to_convert, np.int32)
-
-        self.assertTrue(can_cast)
-
-    def test__can_cast_to_int32__int16_is_true(self):
-        array_to_convert = Series(data=[1, 2, 3], dtype=np.dtype(np.int16))
-
-        can_cast = can_cast_to_int(array_to_convert, np.int32)
-
-        self.assertTrue(can_cast)
-
-    def test__can_cast_to_int32__int64_with_large_value_is_false(self):
-        array_to_convert = Series(data=[3000000000, 2, 3], dtype=np.dtype(np.int64))
-
-        can_cast = can_cast_to_int(array_to_convert, np.int32)
-
-        self.assertFalse(can_cast)
-
-    def test__can_cast_to_int32__int64_with_nans_is_false(self):
-        array_to_convert = Series(data=[np.NaN, "2", "3"], dtype="category")
-
-        can_cast = can_cast_to_int(array_to_convert, np.int32)
-
-        self.assertFalse(can_cast)
-
-    def test__get_encoding_dtype_of_array__supported_dtypes_return_as_expected(self):
-        types = [np.float32, np.int32, np.bool_, str]
-        expected_dtypes = [np.float32, np.int32, np.uint8, str]
-
-        for test_type_index in range(len(types)):
-            with self.subTest(
-                f"Testing get_encoding_dtype_of_array with type {types[test_type_index].__name__}", i=test_type_index
-            ):
-                array = Series(data=[], dtype=types[test_type_index])
-                self.assertEqual(get_encoding_dtype_of_array(array), expected_dtypes[test_type_index])
-
-    def test__get_encoding_dtype_of_array__categories_return_as_expected(self):
-        array = Series(data=["a", "b", "c"], dtype="category")
-        expected_dtype = str
-
-        actual_dtype = get_encoding_dtype_of_array(array)
-
-        self.assertEqual(expected_dtype, actual_dtype)
-
-    def test__get_encoding_dtype_of_array__unordered_integer_categories_return_as_expected(self):
-        array = Series(data=[2, 3, 1, 3, 1, 2], dtype="category")
-        expected_dtype = np.int32
-
-        actual_dtype = get_encoding_dtype_of_array(array)
-
-        self.assertEqual(expected_dtype, actual_dtype)
-
-    def test__get_encoding_dtype_of_array__castable_dtypes_return_as_expected(self):
-        types = [np.float64, np.int64]
-        expected_dtypes = [np.float32, np.int32]
-
-        for test_type_index in range(len(types)):
-            with self.subTest(
-                f"Testing get_encoding_dtype_of_array with castable type {types[test_type_index].__name__}",
-                i=test_type_index,
-            ):
-                array = Series(data=[], dtype=types[test_type_index])
-                self.assertEqual(get_encoding_dtype_of_array(array), expected_dtypes[test_type_index])
-
-    def test__get_encoding_dtype_of_array__unsupported_type_raises_exception(self):
-        unsupported_array = Series(list([time() for _ in range(2)]), dtype="datetime64[ns]")
-
-        with self.assertRaises(TypeError) as exception_context:
-            get_encoding_dtype_of_array(unsupported_array)
-
-        self.assertIn("unsupported", str(exception_context.exception))
-
-    def test__get_schema_type_hint_of_array__supported_dtypes_return_as_expected(self):
-        types = [np.float32, np.int32, np.bool_, str]
-        expected_schema_hints = [{"type": "float32"}, {"type": "int32"}, {"type": "boolean"}, {"type": "string"}]
-
-        for test_type_index in range(len(types)):
-            with self.subTest(
-                f"Testing get_schema_type_hint_of_array with type {types[test_type_index].__name__}", i=test_type_index
-            ):
-                array = Series(data=[], dtype=types[test_type_index])
-                self.assertEqual(get_schema_type_hint_of_array(array), expected_schema_hints[test_type_index])
-
-    def test__get_schema_type_hint_of_array__categories_return_as_expected(self):
-        array = Series(data=["a", "b", "b"], dtype="category")
-        expected_schema_hint = {"type": "categorical", "categories": ["a", "b"]}
-
-        actual_schema_hint = get_schema_type_hint_of_array(array)
-
-        self.assertEqual(expected_schema_hint, actual_schema_hint)
-
-    def test__get_schema_type_hint_of_array__castable_dtypes_return_as_expected(self):
-        types = [np.float64, np.int64]
-        expected_schema_hints = [{"type": "float32"}, {"type": "int32"}]
-
-        for test_type_index in range(len(types)):
-            with self.subTest(
-                f"Testing get_schema_type_hint_of_array with castable type {types[test_type_index].__name__}",
-                i=test_type_index,
-            ):
-                array = Series(data=[], dtype=types[test_type_index])
-                self.assertEqual(get_schema_type_hint_of_array(array), expected_schema_hints[test_type_index])
-
     def test__get_dtypes_and_schemas_of_dataframe__dtype_and_schema_returns_as_expected(self):
         float_array = Series(data=[1, 2, 3], dtype=np.dtype(np.float64))
         category_array = Series(data=["a", "b", "b"], dtype="category")
@@ -194,31 +35,20 @@ class TestTypeConversionUtils(unittest.TestCase):
         self.assertEqual(expected_data_types_dict, actual_dataframe_data_types)
         self.assertEqual(expected_schema_type_hints_dict, actual_dataframe_schema_type_hints)
 
-    def test__convert_pandas_series_to_numpy__categorical_float64_to_float64_with_nans(self):
-        expected_float_array = np.array([1.1, 2.2, np.NaN], dtype=np.float64)
-        float_series = Series(data=[1.1, 2.2, np.NaN], dtype="category")
+    def test__get_schema_type_hint_from_dtype(self):
+        self.assertEqual(get_schema_type_hint_from_dtype(np.dtype(np.bool_)), {"type": "boolean"})
 
-        actual_float_array = convert_pandas_series_to_numpy(float_series, np.float64)
+        for dtype in [np.int8, np.int8, np.int16, np.uint16, np.int32]:
+            self.assertEqual(get_schema_type_hint_from_dtype(np.dtype(dtype)), {"type": "int32"})
+        for dtype in [np.uint32, np.int64, np.uint64]:
+            with self.assertRaises(TypeError):
+                get_schema_type_hint_from_dtype(np.dtype(dtype))
 
-        np.testing.assert_equal(expected_float_array, actual_float_array)
+        for dtype in [np.float16, np.float32, np.float64]:
+            self.assertEqual(get_schema_type_hint_from_dtype(np.dtype(dtype)), {"type": "float32"})
 
-    def test__convert_pandas_series_to_numpy__float64_to_float64(self):
-        expected_float_array = np.array([1.1, 2.2], dtype=np.float64)
-        float_series = Series(data=[1.1, 2.2], dtype=np.dtype(np.float64))
-
-        actual_float_array = convert_pandas_series_to_numpy(float_series, np.float64)
-
-        np.testing.assert_equal(expected_float_array, actual_float_array)
-
-    def test__convert_pandas_series_to_numpy__int64_to_int32_with_nans_throws_error(self):
-        int_series = Series(data=[1, 2, np.NaN], dtype="category")
-
-        with self.assertLogs(level="ERROR") as logger:
-            convert_pandas_series_to_numpy(int_series, np.int32)
-
-            self.assertIn(
-                "Cannot convert a pandas Series object to an integer dtype if it contains NA values.", logger.output[0]
-            )
+        for dtype in [np.dtype(object), np.dtype(str)]:
+            self.assertEqual(get_schema_type_hint_from_dtype(dtype), {"type": "string"})
 
 
 # Credit: https://stackoverflow.com/questions/35871815/python-3-unit-testing-assert-logger-not-called/64774103#64774103
@@ -471,6 +301,10 @@ class TestTypeInference(unittest.TestCase, AssertNoLog):
         if throws:
             with self.assertRaises(throws):
                 get_dtype_and_schema_of_array(self.data)
+            with self.assertRaises(throws):
+                get_encoding_dtype_of_array(self.data)
+            with self.assertRaises(throws):
+                get_schema_type_hint_of_array(self.data)
 
         else:
             logs = getattr(self, "logs", None)
@@ -486,3 +320,7 @@ class TestTypeInference(unittest.TestCase, AssertNoLog):
                     encoding_dtype, schema_hint = get_dtype_and_schema_of_array(self.data)
                     self.assertEqual(encoding_dtype, self.expected_encoding_dtype)
                     self.assertEqual(schema_hint, self.expected_schema_hint)
+
+            # also test the other public API
+            self.assertEqual(get_encoding_dtype_of_array(self.data), self.expected_encoding_dtype)
+            self.assertEqual(get_schema_type_hint_of_array(self.data), self.expected_schema_hint)

--- a/tests/unit/backend/corpora/common/utils/test_type_conversion_utils.py
+++ b/tests/unit/backend/corpora/common/utils/test_type_conversion_utils.py
@@ -1,16 +1,21 @@
 import unittest
+import logging
 from time import time
 from unittest.mock import patch
+from parameterized import parameterized_class
 
 import numpy as np
+import pandas as pd
 from pandas import Series, DataFrame
+from scipy import sparse
 
 from backend.corpora.common.utils.type_conversion_utils import (
     can_cast_to_float32,
-    can_cast_to_int32,
-    get_dtype_of_array,
+    can_cast_to_int,
+    get_encoding_dtype_of_array,
     get_schema_type_hint_of_array,
     get_dtypes_and_schemas_of_dataframe,
+    get_dtype_and_schema_of_array,
     convert_pandas_series_to_numpy,
 )
 
@@ -19,7 +24,7 @@ class TestTypeConversionUtils(unittest.TestCase):
     def test__can_cast_to_float32__string_is_false(self):
         array_to_convert = Series(data=["1", "2", "3"], dtype=str)
 
-        can_cast = can_cast_to_float32(array_to_convert.dtype, array_to_convert)
+        can_cast = can_cast_to_float32(array_to_convert)
 
         self.assertFalse(can_cast)
 
@@ -27,7 +32,7 @@ class TestTypeConversionUtils(unittest.TestCase):
         array_to_convert = Series(data=[1, 2, 3], dtype=np.dtype(np.float64))
 
         with self.assertLogs(level="WARN") as logger:
-            can_cast = can_cast_to_float32(array_to_convert.dtype, array_to_convert)
+            can_cast = can_cast_to_float32(array_to_convert)
             self.assertIn("may lose precision", logger.output[0])
 
         self.assertTrue(can_cast)
@@ -36,7 +41,7 @@ class TestTypeConversionUtils(unittest.TestCase):
     def test__can_cast_to_float32__float32_is_false(self, mock_log_warning):
         array_to_convert = Series(data=[1, 2, 3], dtype=np.dtype(np.float32))
 
-        can_cast = can_cast_to_float32(array_to_convert.dtype, array_to_convert)
+        can_cast = can_cast_to_float32(array_to_convert)
 
         self.assertTrue(can_cast)
         assert not mock_log_warning.called
@@ -44,102 +49,101 @@ class TestTypeConversionUtils(unittest.TestCase):
     def test__can_cast_to_float32__categorical_float64_is_false(self):
         array_to_convert = Series(data=[1.1, 2.2, 3.3], dtype="category")
 
-        can_cast = can_cast_to_float32(array_to_convert.dtype, array_to_convert)
+        can_cast = can_cast_to_float32(array_to_convert)
 
         self.assertFalse(can_cast)
 
     def test__can_cast_to_float32__categorical_int64_with_nans_is_true(self):
         array_to_convert = Series(data=[1, 2, np.NaN], dtype="category")
-
-        can_cast = can_cast_to_float32(array_to_convert.dtype, array_to_convert)
-
-        self.assertTrue(can_cast)
+        self.assertFalse(can_cast_to_float32(array_to_convert))
+        self.assertTrue(can_cast_to_float32(array_to_convert.to_numpy()))
 
     def test__can_cast_to_float_32__float_32_with_nans_is_true(self):
         array_to_convert = Series(data=[1, 2, np.NaN], dtype=np.dtype(np.float32))
 
-        can_cast = can_cast_to_float32(array_to_convert.dtype, array_to_convert)
+        can_cast = can_cast_to_float32(array_to_convert)
 
         self.assertTrue(can_cast)
 
     def test__can_cast_to_int32__string_is_false(self):
         array_to_convert = Series(data=["1", "2", "3"], dtype=str)
 
-        can_cast = can_cast_to_int32(array_to_convert.dtype, array_to_convert)
+        can_cast = can_cast_to_int(array_to_convert, np.int32)
 
         self.assertFalse(can_cast)
 
     def test__can_cast_to_int32__int64_is_true(self):
-        array_to_convert = Series(data=["1", "2", "3"], dtype=np.dtype(np.int64))
+        array_to_convert = Series(data=[1, 2, 3], dtype=np.dtype(np.int64))
 
-        can_cast = can_cast_to_int32(array_to_convert.dtype, array_to_convert)
+        can_cast = can_cast_to_int(array_to_convert, np.int32)
 
         self.assertTrue(can_cast)
 
     def test__can_cast_to_int32__int16_is_true(self):
-        array_to_convert = Series(data=["1", "2", "3"], dtype=np.dtype(np.int16))
+        array_to_convert = Series(data=[1, 2, 3], dtype=np.dtype(np.int16))
 
-        can_cast = can_cast_to_int32(array_to_convert.dtype, array_to_convert)
+        can_cast = can_cast_to_int(array_to_convert, np.int32)
 
         self.assertTrue(can_cast)
 
     def test__can_cast_to_int32__int64_with_large_value_is_false(self):
-        array_to_convert = Series(data=["3000000000", "2", "3"], dtype=np.dtype(np.int64))
+        array_to_convert = Series(data=[3000000000, 2, 3], dtype=np.dtype(np.int64))
 
-        can_cast = can_cast_to_int32(array_to_convert.dtype, array_to_convert)
+        can_cast = can_cast_to_int(array_to_convert, np.int32)
 
         self.assertFalse(can_cast)
 
     def test__can_cast_to_int32__int64_with_nans_is_false(self):
         array_to_convert = Series(data=[np.NaN, "2", "3"], dtype="category")
 
-        can_cast = can_cast_to_int32(array_to_convert.dtype, array_to_convert)
+        can_cast = can_cast_to_int(array_to_convert, np.int32)
 
         self.assertFalse(can_cast)
 
-    def test__get_dtype_of_array__supported_dtypes_return_as_expected(self):
+    def test__get_encoding_dtype_of_array__supported_dtypes_return_as_expected(self):
         types = [np.float32, np.int32, np.bool_, str]
         expected_dtypes = [np.float32, np.int32, np.uint8, str]
 
         for test_type_index in range(len(types)):
             with self.subTest(
-                f"Testing get_dtype_of_array with type {types[test_type_index].__name__}", i=test_type_index
+                f"Testing get_encoding_dtype_of_array with type {types[test_type_index].__name__}", i=test_type_index
             ):
                 array = Series(data=[], dtype=types[test_type_index])
-                self.assertEqual(get_dtype_of_array(array), expected_dtypes[test_type_index])
+                self.assertEqual(get_encoding_dtype_of_array(array), expected_dtypes[test_type_index])
 
-    def test__get_dtype_of_array__categories_return_as_expected(self):
+    def test__get_encoding_dtype_of_array__categories_return_as_expected(self):
         array = Series(data=["a", "b", "c"], dtype="category")
         expected_dtype = str
 
-        actual_dtype = get_dtype_of_array(array)
+        actual_dtype = get_encoding_dtype_of_array(array)
 
         self.assertEqual(expected_dtype, actual_dtype)
 
-    def test__get_dtype_of_array__unordered_integer_categories_return_as_expected(self):
+    def test__get_encoding_dtype_of_array__unordered_integer_categories_return_as_expected(self):
         array = Series(data=[2, 3, 1, 3, 1, 2], dtype="category")
         expected_dtype = np.int32
 
-        actual_dtype = get_dtype_of_array(array)
+        actual_dtype = get_encoding_dtype_of_array(array)
 
         self.assertEqual(expected_dtype, actual_dtype)
 
-    def test__get_dtype_of_array__castable_dtypes_return_as_expected(self):
+    def test__get_encoding_dtype_of_array__castable_dtypes_return_as_expected(self):
         types = [np.float64, np.int64]
         expected_dtypes = [np.float32, np.int32]
 
         for test_type_index in range(len(types)):
             with self.subTest(
-                f"Testing get_dtype_of_array with castable type {types[test_type_index].__name__}", i=test_type_index
+                f"Testing get_encoding_dtype_of_array with castable type {types[test_type_index].__name__}",
+                i=test_type_index,
             ):
                 array = Series(data=[], dtype=types[test_type_index])
-                self.assertEqual(get_dtype_of_array(array), expected_dtypes[test_type_index])
+                self.assertEqual(get_encoding_dtype_of_array(array), expected_dtypes[test_type_index])
 
-    def test__get_dtype_of_array__unsupported_type_raises_exception(self):
+    def test__get_encoding_dtype_of_array__unsupported_type_raises_exception(self):
         unsupported_array = Series(list([time() for _ in range(2)]), dtype="datetime64[ns]")
 
         with self.assertRaises(TypeError) as exception_context:
-            get_dtype_of_array(unsupported_array)
+            get_encoding_dtype_of_array(unsupported_array)
 
         self.assertIn("unsupported", str(exception_context.exception))
 
@@ -213,5 +217,272 @@ class TestTypeConversionUtils(unittest.TestCase):
             convert_pandas_series_to_numpy(int_series, np.int32)
 
             self.assertIn(
-                "Cannot convert a pandas Series object to an integer dtype if it contains NaNs", logger.output[0]
+                "Cannot convert a pandas Series object to an integer dtype if it contains NA values.", logger.output[0]
             )
+
+
+# Credit: https://stackoverflow.com/questions/35871815/python-3-unit-testing-assert-logger-not-called/64774103#64774103
+class AssertNoLog:
+    def assertNoLogs(self, logger, level):
+        """functions as a context manager.  To be introduced in python 3.10"""
+
+        class AssertNoLogsContext(unittest.TestCase):
+            def __init__(self, logger, level):
+                self.logger = logger
+                self.level = level
+                self.context = self.assertLogs(logger, level)
+
+            def __enter__(self):
+                """enter self.assertLogs as context manager, and log something"""
+                self.initial_logmsg = "sole message"
+                self.cm = self.context.__enter__()
+                self.logger.log(self.level, self.initial_logmsg)
+                return self.cm
+
+            def __exit__(self, exc_type, exc_val, exc_tb):
+                """cleanup logs, and then check nothing extra was logged"""
+                # assertLogs.__exit__ should never fail because of initial msg
+                self.context.__exit__(exc_type, exc_val, exc_tb)
+                if len(self.cm.output) > 1:
+                    """override any exception passed to __exit__"""
+                    self.context._raiseFailure(
+                        "logs of level {} or higher triggered on {} : {}".format(
+                            logging.getLevelName(self.level), self.logger.name, self.cm.output[1:]
+                        )
+                    )
+
+        return AssertNoLogsContext(logger, level)
+
+
+"""
+See table of expected cases in type_conversion_utils.py.
+
+This probes all edge cases. Each case is a dict containing keys:
+    - data - the array to be introspected
+    - throws - if not None, the expected Error (eg, TypeError)
+    - expected_encoding_dtype - upon success
+    - expected_schema_hint - upon success
+    - logs - if not None, specify expected log output
+"""
+
+bool_OK_cases = [
+    {
+        "data": data,
+        "expected_encoding_dtype": np.uint8,
+        "expected_schema_hint": {"type": "boolean"},
+    }
+    for data in [
+        np.array([0, 1, 0, 1], dtype=np.bool_),
+        pd.Series(np.array([0, 1, 0, 1], dtype=np.bool_)),
+        # pd.Index with bools doesn't really make any sense...and becomes dtype=object
+    ]
+]
+
+int_OK_cases = [
+    {
+        "data": data,
+        "expected_encoding_dtype": np.int32,
+        "expected_schema_hint": {"type": "int32"},
+    }
+    for dtype in [np.int8, np.uint8, np.int16, np.uint16, np.int32, np.uint32, np.int64, np.uint64]
+    for data in [
+        np.arange(0, 1000, dtype=dtype),
+        pd.Series(np.arange(0, 1000, dtype=dtype)),
+        pd.Index(np.arange(0, 1000, dtype=dtype)),
+        sparse.csr_matrix((10, 100), dtype=dtype),
+    ]
+]
+
+float_OK_cases = [
+    {
+        "data": data,
+        "expected_encoding_dtype": np.float32,
+        "expected_schema_hint": {"type": "float32"},
+        "logs": None if data.dtype != np.float64 else {"level": logging.WARNING, "output": "may lose precision"},
+    }
+    for dtype in [np.float16, np.float32, np.float64]
+    for data in [
+        np.arange(-128, 1000, dtype=dtype),
+        pd.Series(np.arange(-128, 1000, dtype=dtype)),
+        pd.Index(np.arange(-129, 1000, dtype=dtype)),
+        np.array([-np.nan, np.NINF, -1, np.NZERO, 0, np.PZERO, 1, np.PINF, np.nan], dtype=dtype),
+        np.array([np.finfo(dtype).min, 0, np.finfo(dtype).max], dtype=dtype),
+        sparse.csr_matrix((10, 100), dtype=dtype),
+    ]
+]
+
+
+numeric_ERR_cases = [
+    {
+        "data": data,
+        "throws": TypeError,
+    }
+    for data in [
+        np.array([np.iinfo(np.int64).min, np.iinfo(np.int64).max], dtype=np.int64),
+        np.array([np.iinfo(np.uint64).min, np.iinfo(np.uint64).max], dtype=np.uint64),
+        np.array([np.iinfo(np.uint32).min, np.iinfo(np.uint32).max], dtype=np.uint32),
+    ]
+]
+
+
+string_OK_cases = [
+    {
+        "data": data,
+        "expected_encoding_dtype": np.dtype(str),
+        "expected_schema_hint": {"type": "string"},
+    }
+    for data in [
+        np.array(["a", "b", "c"]),
+        np.array(["a", "b", "c"], dtype="object"),
+        pd.Series(["a", "b", "c"]),
+        pd.Index(["a", "b", "c"]),
+        np.array(["a", [], {}, None, True, False, 383.2], dtype="object"),
+    ]
+]
+
+category_nonnumeric_OK_cases = [
+    {
+        "data": data,
+        "expected_encoding_dtype": np.dtype(str),
+        "expected_schema_hint": {"type": "categorical", "categories": data.dtype.categories.to_list()},
+    }
+    for data in [
+        pd.Series(["a", "b", "c"], dtype="category"),
+        pd.Series(["a", "b", "c", 0, 1, 2], dtype="category"),
+        pd.Series(["a", "b", "c"], dtype="category").cat.remove_categories(["b"]),
+        pd.Series(["a", "b", "c", 0, 1, 2], dtype="category").cat.remove_categories(["b", 0]),
+    ]
+]
+
+category_numeric_OK_cases = [
+    # numeric, no NA/NaN, int
+    *[
+        {
+            "data": data,
+            "expected_encoding_dtype": np.int32,
+            "expected_schema_hint": {"type": "categorical"},
+        }
+        for dtype in [np.int8, np.uint8, np.int16, np.uint16, np.int32, np.uint32, np.int64, np.uint64]
+        for data in [
+            pd.Series(np.array([0, 1, 2], dtype=dtype), dtype="category"),
+        ]
+    ],
+    # numeric, no NA/NaN, float
+    *[
+        {
+            "data": data,
+            "expected_encoding_dtype": np.float32,
+            "expected_schema_hint": {"type": "categorical"},
+            "logs": {"level": logging.WARNING, "output": "may lose precision"},
+        }
+        for dtype in [np.float16, np.float32, np.float64]
+        for data in [
+            pd.Series(np.array([0, 1, 2], dtype=dtype), dtype="category"),
+            pd.Series(np.array([0, 1, 2], dtype=dtype), dtype="category").cat.remove_categories([1]),
+            pd.Categorical(np.array([0, 1, 2], dtype=dtype)),
+        ]
+    ],
+    # numeric, has NA-induced cast to float32
+    *[
+        {
+            "data": data,
+            "expected_encoding_dtype": np.float32,
+            "expected_schema_hint": {"type": "categorical"},
+            "logs": {"level": logging.WARNING, "output": "may lose precision"},
+        }
+        for dtype in [
+            np.int8,
+            np.uint8,
+            np.int16,
+            np.uint16,
+            np.int32,
+            np.uint32,
+            np.int64,
+            np.uint64,
+            np.float16,
+            np.float32,
+            np.float64,
+        ]
+        for data in [
+            pd.Series(np.array([0, 1, 2], dtype=dtype), dtype="category").cat.remove_categories([1]),
+            pd.Categorical(np.array([0, 1, 2], dtype=dtype), categories=np.array([0, 1], dtype=dtype)),
+        ]
+    ],
+]
+
+category_ERR_cases = [
+    # catch expected categorical exceptions for Int64(etc) that have large values
+    {
+        "data": data,
+        "throws": TypeError,
+    }
+    for data in [
+        pd.Categorical(np.array([np.iinfo(np.int64).min, np.iinfo(np.int64).max], dtype=np.int64)),
+        pd.Categorical(np.array([np.iinfo(np.uint64).min, np.iinfo(np.uint64).max], dtype=np.uint64)),
+        pd.Categorical(np.array([np.iinfo(np.uint32).min, np.iinfo(np.uint32).max], dtype=np.uint32)),
+    ]
+]
+
+object_OK_cases = [
+    {
+        "data": data,
+        "expected_encoding_dtype": np.dtype(str),
+        "expected_schema_hint": {"type": "string"},
+    }
+    for data in [
+        np.array(["a", True, 1, [], {}], dtype="object"),
+        pd.Series(["a", True, 1, [], {}], dtype="object"),
+        pd.Index(["a", True, 1, [], {}], dtype="object"),
+    ]
+]
+
+err_cases = [
+    {"data": np.array, "throws": TypeError}
+    for data in [
+        np.ones((10,), dtype=np.complex64),
+        np.ones((10,), dtype=np.complex128),
+        np.array([b"foobar"], dtype=np.bytes_),
+        np.ones((10,), dtype=np.void),
+        np.arange("2005-02", "2005-03", dtype="datetime64[D]"),
+        np.arange("2005-02", "2005-03", dtype="datetime64[D]") - np.datetime64("2008-01-01"),
+        [],
+        {},
+    ]
+]
+
+test_cases = [
+    *bool_OK_cases,
+    *int_OK_cases,
+    *float_OK_cases,
+    *numeric_ERR_cases,
+    *string_OK_cases,
+    *category_nonnumeric_OK_cases,
+    *category_numeric_OK_cases,
+    *category_ERR_cases,
+    *object_OK_cases,
+    *err_cases,
+]
+
+
+@parameterized_class(test_cases)
+class TestTypeInference(unittest.TestCase, AssertNoLog):
+    def test_type_inference(self):
+        throws = getattr(self, "throws", None)
+        if throws:
+            with self.assertRaises(throws):
+                get_dtype_and_schema_of_array(self.data)
+
+        else:
+            logs = getattr(self, "logs", None)
+            if logs is not None:
+                with self.assertLogs(level=logs["level"]) as logger:
+                    encoding_dtype, schema_hint = get_dtype_and_schema_of_array(self.data)
+                    self.assertEqual(encoding_dtype, self.expected_encoding_dtype)
+                    self.assertEqual(schema_hint, self.expected_schema_hint)
+                    self.assertIn(logs["output"], logger.output[0])
+
+            else:
+                with self.assertNoLogs(logging.getLogger(), logging.WARNING):
+                    encoding_dtype, schema_hint = get_dtype_and_schema_of_array(self.data)
+                    self.assertEqual(encoding_dtype, self.expected_encoding_dtype)
+                    self.assertEqual(schema_hint, self.expected_schema_hint)


### PR DESCRIPTION
This PR makes the same fixes as chanzuckerberg/cellxgene#2332

In particular:
* type inferencing from H5AD is clarified, most specifically in cases where casts are required
* add tests to confirm proper behavior

This code is _duplicated_ in this repo from the cellxgene repo.  The cellxgene repo should be considered authoratative, as CXG is a cellxgene-private data structure, and many additional tests are performed in that repo. 