### PR TITLE
fix: update processing status instead of upload status on failure

### DIFF
--- a/backend/corpora/lambdas/upload_failures/upload.py
+++ b/backend/corpora/lambdas/upload_failures/upload.py
@@ -1,5 +1,5 @@
 from backend.corpora.common.entities import Dataset
-from backend.corpora.common.corpora_orm import UploadStatus, DbDatasetProcessingStatus
+from backend.corpora.common.corpora_orm import UploadStatus, DbDatasetProcessingStatus, ProcessingStatus
 from backend.corpora.common.utils.db_helpers import processing_status_updater
 from backend.corpora.common.utils.db_session import db_session_manager
 
@@ -9,14 +9,12 @@ def update_dataset_processing_status_to_failed(dataset_uuid, error=None) -> None
     This functions updates the processing status for a given dataset uuid to failed
     """
     try:
-        status = {
-            DbDatasetProcessingStatus.upload_progress: 0,
-            DbDatasetProcessingStatus.upload_status: UploadStatus.FAILED,
-            DbDatasetProcessingStatus.upload_message: str(error),
-        }
-
         with db_session_manager() as session:
             dataset = Dataset.get(session, dataset_uuid)
+            status = {
+                DbDatasetProcessingStatus.processing_status: ProcessingStatus.FAILURE,
+                DbDatasetProcessingStatus.upload_message: str(error),
+            }
             processing_status_updater(session, dataset.processing_status.id, status)
     # If dataset not in db dont worry about updating its processing status
     except AttributeError:

--- a/backend/corpora/lambdas/upload_failures/upload.py
+++ b/backend/corpora/lambdas/upload_failures/upload.py
@@ -1,5 +1,5 @@
 from backend.corpora.common.entities import Dataset
-from backend.corpora.common.corpora_orm import UploadStatus, DbDatasetProcessingStatus, ProcessingStatus
+from backend.corpora.common.corpora_orm import DbDatasetProcessingStatus, ProcessingStatus
 from backend.corpora.common.utils.db_helpers import processing_status_updater
 from backend.corpora.common.utils.db_session import db_session_manager
 

--- a/frontend/src/components/Collections/components/Grid/components/Row/DatasetRow/components/Tooltip/index.tsx
+++ b/frontend/src/components/Collections/components/Grid/components/Row/DatasetRow/components/Tooltip/index.tsx
@@ -53,9 +53,7 @@ const ERROR_TO_CONTENT: { [key: string]: Content } = {
   },
   [FAILED_RETURN_TYPE.UPLOAD + UPLOAD_STATUS.FAILED]: {
     color: RED.C,
-    content: (
-      <span>There was a problem uploading your file.</span>
-    ),
+    content: <span>There was a problem uploading your file.</span>,
     intent: Intent.DANGER,
   },
 };

--- a/frontend/src/components/Collections/components/Grid/components/Row/DatasetRow/components/Tooltip/index.tsx
+++ b/frontend/src/components/Collections/components/Grid/components/Row/DatasetRow/components/Tooltip/index.tsx
@@ -54,7 +54,7 @@ const ERROR_TO_CONTENT: { [key: string]: Content } = {
   [FAILED_RETURN_TYPE.UPLOAD + UPLOAD_STATUS.FAILED]: {
     color: RED.C,
     content: (
-      <span>There was a problem uploading your file. Please try again.</span>
+      <span>There was a problem uploading your file.</span>
     ),
     intent: Intent.DANGER,
   },

--- a/tests/unit/backend/corpora/api_server/test_v1_auth.py
+++ b/tests/unit/backend/corpora/api_server/test_v1_auth.py
@@ -63,6 +63,7 @@ class TestAuth(BaseAuthAPITest):
             # check userinfo
             response = self.app.get("/dp/v1/userinfo", headers=dict(host="localhost", Cookie=cxguser_cookie))
             self.assertEqual(200, response.status_code)
+
             body = json.loads(response.data)
             self.check_user_info(body)
             self.assertNotIn("Set-Cookie", response.headers)  # no cookie expected

--- a/tests/unit/backend/corpora/common/entities/datasets/test_update.py
+++ b/tests/unit/backend/corpora/common/entities/datasets/test_update.py
@@ -2,7 +2,7 @@ from backend.corpora.common.corpora_orm import (
     DatasetArtifactFileType,
     DatasetArtifactType,
     DbDatasetProcessingStatus,
-    UploadStatus,
+    UploadStatus, ProcessingStatus,
 )
 from backend.corpora.common.entities import Dataset
 from backend.corpora.common.utils.db_helpers import processing_status_updater
@@ -65,7 +65,9 @@ class TestUpdateDataset(TestDataset):
         self.session.expire_all()
 
         dataset = Dataset.get(self.session, self.uuid)
-        self.assertEqual(dataset.processing_status.upload_status, UploadStatus.FAILED)
+        self.assertEqual(dataset.processing_status.processing_status, ProcessingStatus.FAILURE)
+        self.assertEqual(dataset.processing_status.upload_status, UploadStatus.WAITING)
+
 
     def test__update_processing_status__no_dataset__ok(self):
         update_dataset_processing_status_to_failed("fake_uuid")

--- a/tests/unit/backend/corpora/common/entities/datasets/test_update.py
+++ b/tests/unit/backend/corpora/common/entities/datasets/test_update.py
@@ -2,7 +2,8 @@ from backend.corpora.common.corpora_orm import (
     DatasetArtifactFileType,
     DatasetArtifactType,
     DbDatasetProcessingStatus,
-    UploadStatus, ProcessingStatus,
+    UploadStatus,
+    ProcessingStatus,
 )
 from backend.corpora.common.entities import Dataset
 from backend.corpora.common.utils.db_helpers import processing_status_updater
@@ -67,7 +68,6 @@ class TestUpdateDataset(TestDataset):
         dataset = Dataset.get(self.session, self.uuid)
         self.assertEqual(dataset.processing_status.processing_status, ProcessingStatus.FAILURE)
         self.assertEqual(dataset.processing_status.upload_status, UploadStatus.WAITING)
-
 
     def test__update_processing_status__no_dataset__ok(self):
         update_dataset_processing_status_to_failed("fake_uuid")


### PR DESCRIPTION
remove message telling users to try again

### Reviewers
**Functional:** 
- @seve 
**Readability:** 

---

## Changes
- remove message telling users to try again on upload failure
- modify upload failure lambda to update the processing status instead of the upload status

## Definition of Done (from ticket)

## QA steps (optional)

## Known Issues
