### PR TITLE
fix: only show revision state on the revision, rename confusing field

### DIFF
--- a/frontend/src/common/entities.ts
+++ b/frontend/src/common/entities.ts
@@ -63,7 +63,7 @@ export interface Collection {
   obfuscated_uuid: string;
   created_at: number;
   updated_at: number;
-  is_revision: boolean;
+  has_revision: boolean;
   revision_diff: boolean;
 }
 

--- a/frontend/src/common/queries/collections.ts
+++ b/frontend/src/common/queries/collections.ts
@@ -118,10 +118,10 @@ function fetchCollection(allCollections: CollectionResponsesMap | undefined) {
         Collection
       >;
 
-      collection.is_revision = collectionsWithID.size > 1;
+      collection.has_revision = collectionsWithID.size > 1;
     }
 
-    if (visibility === VISIBILITY_TYPE.PRIVATE && collection.is_revision) {
+    if (visibility === VISIBILITY_TYPE.PRIVATE && collection.has_revision) {
       response = await fetch(baseUrl, DEFAULT_FETCH_OPTIONS);
       json = await response.json();
 
@@ -134,7 +134,7 @@ function fetchCollection(allCollections: CollectionResponsesMap | undefined) {
     }
 
     // check for diffs between revision and published collection
-    if (collection.is_revision && visibility === VISIBILITY_TYPE.PRIVATE) {
+    if (collection.has_revision && visibility === VISIBILITY_TYPE.PRIVATE) {
       collection.revision_diff = checkForRevisionChange(
         collection,
         publishedCounterpart
@@ -339,7 +339,7 @@ export function useEditCollection(collectionID?: Collection["id"]) {
         [USE_COLLECTION, collectionID, VISIBILITY_TYPE.PRIVATE],
         () => {
           const revision_diff =
-            collection?.is_revision && publishedCollection
+            collection?.has_revision && publishedCollection
               ? checkForRevisionChange(newCollection, publishedCollection)
               : null;
           return { ...collection, ...newCollection, revision_diff };

--- a/frontend/src/common/utils/checkForRevisionChange.ts
+++ b/frontend/src/common/utils/checkForRevisionChange.ts
@@ -7,7 +7,7 @@ const IGNORED_COLLECTION_FIELDS = [
   "visibility",
   "created_at",
   "updated_at",
-  "is_revision",
+  "has_revision",
   "revision_diff",
   "datasets",
   "genesets",

--- a/frontend/src/components/Collections/components/Grid/components/Row/CollectionRow/index.tsx
+++ b/frontend/src/components/Collections/components/Grid/components/Row/CollectionRow/index.tsx
@@ -53,7 +53,7 @@ const CollectionRow: FC<Props> = (props) => {
   const [mutate] = useCreateRevision(navigateToRevision);
 
   const handleRevisionClick = () => {
-    if (collection?.is_revision === false) {
+    if (collection?.has_revision === false) {
       mutate(id);
     } else {
       navigateToRevision();
@@ -100,7 +100,7 @@ const CollectionRow: FC<Props> = (props) => {
             >
               {isPrivate ? "Private" : "Published"}
             </Tag>
-            {props.revisionsEnabled && collection.is_revision && (
+            {props.revisionsEnabled && collection.has_revision && (
               <Tag minimal intent={Intent.PRIMARY}>
                 Revision Pending
               </Tag>
@@ -115,7 +115,7 @@ const CollectionRow: FC<Props> = (props) => {
       <RightAlignedDetailsCell>{cell_count || "-"}</RightAlignedDetailsCell>
       {props.revisionsEnabled && visibility === VISIBILITY_TYPE.PUBLIC ? (
         <RevisionCell
-          isRevision={collection.is_revision}
+          isRevision={collection.has_revision}
           handleRevisionClick={handleRevisionClick}
         />
       ) : (

--- a/frontend/src/views/Collection/index.tsx
+++ b/frontend/src/views/Collection/index.tsx
@@ -66,7 +66,7 @@ const Collection: FC = () => {
   const { data: collection, isError, isFetching } = collectionState;
 
   const revisionsEnabled = get(FEATURES.REVISION) === BOOLEAN.TRUE;
-  const isRevision = revisionsEnabled && !!collection?.is_revision;
+  const isRevision = revisionsEnabled && !!collection?.has_revision;
 
   const [selectedTab, setSelectedTab] = useState(TABS.DATASETS);
 
@@ -124,7 +124,7 @@ const Collection: FC = () => {
         <title>cellxgene | {collection.name}</title>
       </Head>
       <ViewGrid>
-        {collection.is_revision && (
+        {collection.has_revision && visibility === VISIBILITY_TYPE.PRIVATE && (
           <StyledCallout intent={Intent.PRIMARY} icon={null}>
             {collection.revision_diff
               ? "This collection has changed since you last published it."


### PR DESCRIPTION
### Reviewers
**Functional:**  @tihuan 

---

## Changes
- modify
  -  actually check if a collection **is** a revision when showing revision state
  - rename `is_revision1 to `has_revision` to better communicate boolean state

