### PR TITLE
fix: check collections map presence when computing revision state

### DIFF
--- a/frontend/src/common/queries/collections.ts
+++ b/frontend/src/common/queries/collections.ts
@@ -113,12 +113,9 @@ function fetchCollection(allCollections: CollectionResponsesMap | undefined) {
     let publishedCounterpart;
 
     if (allCollections) {
-      const collectionsWithID = allCollections.get(id) as Map<
-        VISIBILITY_TYPE,
-        Collection
-      >;
+      const collectionsWithID = allCollections.get(id);
 
-      collection.has_revision = collectionsWithID.size > 1;
+      collection.has_revision = collectionsWithID && collectionsWithID.size > 1;
     }
 
     if (visibility === VISIBILITY_TYPE.PRIVATE && collection.has_revision) {


### PR DESCRIPTION
### Reviewers
**Functional:**  @tihuan 
---
