### PR TITLE
fix: disable buttons on deleted dataset

### DIFF
--- a/frontend/src/components/Collections/components/Dataset/components/DownloadDataset/index.tsx
+++ b/frontend/src/components/Collections/components/Dataset/components/DownloadDataset/index.tsx
@@ -31,7 +31,7 @@ const DownloadDataset: FC<Props> = ({
 
   return (
     <>
-      <Tooltip content="Download">
+      <Tooltip content="Download" disabled={isDisabled}>
         <Button
           disabled={isDisabled || !dataAssets.length}
           onClick={toggleOpen}

--- a/frontend/src/components/Collections/components/Grid/components/Row/DatasetRow/components/MoreDropdown/index.tsx
+++ b/frontend/src/components/Collections/components/Grid/components/Row/DatasetRow/components/MoreDropdown/index.tsx
@@ -10,6 +10,7 @@ interface Props {
   revisionsEnabled: boolean;
   onUploadFile: ChooserProps["onUploadFile"];
   isLoading: boolean;
+  disabled: boolean;
 }
 
 const MoreDropdown = ({
@@ -18,6 +19,7 @@ const MoreDropdown = ({
   revisionsEnabled,
   onUploadFile,
   isLoading,
+  disabled,
 }: Props) => {
   const popoverProps = useMemo(() => {
     return {
@@ -30,11 +32,21 @@ const MoreDropdown = ({
           isLoading={isLoading}
         />
       ),
+      disabled,
       position: Position.BOTTOM,
     };
-  }, [collectionId, datasetId, revisionsEnabled, isLoading, onUploadFile]);
+  }, [
+    collectionId,
+    datasetId,
+    revisionsEnabled,
+    isLoading,
+    onUploadFile,
+    disabled,
+  ]);
 
-  return <RawMoreDropdown popoverProps={popoverProps} />;
+  return (
+    <RawMoreDropdown popoverProps={popoverProps} buttonProps={{ disabled }} />
+  );
 };
 
 export default MoreDropdown;

--- a/frontend/src/components/Collections/components/Grid/components/Row/DatasetRow/index.tsx
+++ b/frontend/src/components/Collections/components/Grid/components/Row/DatasetRow/index.tsx
@@ -200,6 +200,7 @@ const DatasetRow: FC<Props> = ({
                   revisionsEnabled={revisionsEnabled}
                   onUploadFile={onUploadFile}
                   isLoading={isLoading}
+                  disabled={dataset.tombstone ?? false}
                 />
               )}
           </ActionButton>
@@ -209,12 +210,13 @@ const DatasetRow: FC<Props> = ({
               name={dataset?.name || ""}
               dataAssets={dataset?.dataset_assets}
               Button={DownloadButton}
+              isDisabled={dataset.tombstone}
             />
           </ActionButton>
 
           <ActionButton>
             {hasCXGFile(dataset) && (
-              <Tooltip content="Explore">
+              <Tooltip content="Explore" disabled={dataset.tombstone ?? false}>
                 <AnchorButton
                   minimal
                   intent={Intent.PRIMARY}
@@ -227,6 +229,7 @@ const DatasetRow: FC<Props> = ({
                   target="_blank"
                   rel="noopener"
                   data-test-id="view-dataset-link"
+                  disabled={dataset.tombstone ?? false}
                 />
               </Tooltip>
             )}


### PR DESCRIPTION
fixes: #1306 

### Reviewers
**Functional:** @tihuan 

**Readability:** 

---

## Changes
- add
  - add disabled props to buttons which are enabled by tombstone status

