### PR TITLE
fix: 1313 revision delete last dataset

### DIFF
--- a/frontend/src/common/queries/collections.ts
+++ b/frontend/src/common/queries/collections.ts
@@ -363,10 +363,10 @@ export function useCreateRevision(callback: () => void) {
   const queryCache = useQueryCache();
 
   return useMutation(createRevision, {
-    onSuccess: (collection: Collection) => {
+    onSuccess: async (collection: Collection) => {
+      await queryCache.invalidateQueries([USE_COLLECTIONS]);
+      await queryCache.invalidateQueries([USE_COLLECTION, collection.id]);
       callback();
-      queryCache.invalidateQueries([USE_COLLECTIONS]);
-      queryCache.invalidateQueries([USE_COLLECTION, collection.id]);
     },
   });
 }

--- a/frontend/src/components/Collections/components/Grid/components/Row/CollectionRow/index.tsx
+++ b/frontend/src/components/Collections/components/Grid/components/Row/CollectionRow/index.tsx
@@ -46,11 +46,14 @@ const CollectionRow: FC<Props> = (props) => {
     id: props.id,
     visibility: props.visibility,
   });
+
   const router = useRouter();
+
   const navigateToRevision = () => {
     router.push(ROUTES.PRIVATE_COLLECTION.replace(":id", id));
   };
-  const [mutate] = useCreateRevision(navigateToRevision);
+
+  const [mutate, { isLoading }] = useCreateRevision(navigateToRevision);
 
   const handleRevisionClick = () => {
     if (collection?.has_revision === false) {
@@ -117,6 +120,7 @@ const CollectionRow: FC<Props> = (props) => {
         <RevisionCell
           isRevision={collection.has_revision}
           handleRevisionClick={handleRevisionClick}
+          isLoading={isLoading}
         />
       ) : (
         <RightAlignedDetailsCell />
@@ -128,13 +132,20 @@ const CollectionRow: FC<Props> = (props) => {
 const RevisionCell = ({
   isRevision,
   handleRevisionClick,
+  isLoading,
 }: {
   isRevision?: boolean;
   handleRevisionClick: () => void;
+  isLoading: boolean;
 }) => {
   return (
     <RightAlignedDetailsCell>
-      <Button intent={Intent.PRIMARY} minimal onClick={handleRevisionClick}>
+      <Button
+        loading={isLoading}
+        intent={Intent.PRIMARY}
+        minimal
+        onClick={handleRevisionClick}
+      >
         {isRevision ? "Continue" : "Start Revision"}
       </Button>
     </RightAlignedDetailsCell>

--- a/frontend/src/components/Collections/components/Grid/components/Row/DatasetRow/components/DeleteDataset/index.tsx
+++ b/frontend/src/components/Collections/components/Grid/components/Row/DatasetRow/components/DeleteDataset/index.tsx
@@ -39,8 +39,8 @@ const DeleteDataset: FC<Props> = ({
       {isOpen && (
         <AsyncAlert
           loading={isLoading}
-          cancelButtonText={"Cancel"}
-          confirmButtonText={"Delete Dataset"}
+          cancelButtonText="Cancel"
+          confirmButtonText="Delete Dataset"
           intent={Intent.DANGER}
           isOpen={isOpen}
           onCancel={toggleAlert}


### PR DESCRIPTION
fixes #1313  #1309

### Reviewers
**Functional:** 

**Readability:** 

---

## Changes
1. We just need to wait for cache invalidation promises to resolve before navigating to the collection
2. Added loading state on "Start Revision" click

![demo](https://user-images.githubusercontent.com/6309723/127936465-ca282ffb-c87d-495b-8b83-0c8e7145b189.gif)


## Definition of Done (from ticket)

## QA steps (optional)

## Known Issues
