### PR TITLE
fix: 1310 Add dataset refresh unexpected error

### DIFF
--- a/frontend/src/views/Collection/components/Toast/index.tsx
+++ b/frontend/src/views/Collection/components/Toast/index.tsx
@@ -1,16 +1,21 @@
 import { IToaster, IToastProps, Position, Toaster } from "@blueprintjs/core";
 
+/**
+ * (thuang): We can't lazy-load toaster via `.create()` on the first `.show()`
+ * call, because sometimes `.show()` is called inside React lifecycle hooks.
+ */
 let toaster: IToaster | null = null;
 
-const Toast = {
-  show(props: IToastProps) {
-    if (!toaster) {
-      toaster = Toaster.create({
-        position: Position.TOP,
-      });
-    }
+// (thuang): Instantiates on the client side only
+if (typeof document !== "undefined") {
+  toaster = Toaster.create({
+    position: Position.TOP,
+  });
+}
 
-    toaster.show(props);
+const Toast = {
+  show(props: IToastProps): void {
+    toaster?.show(props);
   },
 };
 


### PR DESCRIPTION
fixes: #1310 

### Reviewers
**Functional:** 
@seve 

**Readability:** 

---

## Changes
1. We can't lazy-load toaster via `.create()` on the first `.show()` call anymore, because sometimes `.show()` is called inside React lifecycle hooks, which doesn't work with React 16+. The solution is to instantiate a Toaster instance on the client side when the file is first loaded

## Definition of Done (from ticket)
1. Upload a dataset
2. Wait till you see the first toaster then refresh the page
3. Wait till you see the second toaster (it should no longer crashes)

## QA steps (optional)

## Known Issues
