### PR TITLE
fix: create cxg after extracting metadata

### DIFF
--- a/backend/corpora/dataset_processing/process.py
+++ b/backend/corpora/dataset_processing/process.py
@@ -473,13 +473,13 @@ def process(dataset_id, dropbox_url, cellxgene_bucket, artifact_bucket):
     )
 
     validate_h5ad_file(dataset_id, local_filename)
-    process_cxg(local_filename, dataset_id, cellxgene_bucket)
 
     # Process metadata
     metadata = extract_metadata(local_filename)
     update_db(dataset_id, metadata)
 
     # create artifacts
+    process_cxg(local_filename, dataset_id, cellxgene_bucket)
     create_artifacts(local_filename, dataset_id, artifact_bucket)
     update_db(dataset_id, processing_status=dict(processing_status=ProcessingStatus.SUCCESS))
 

--- a/frontend/src/components/Collections/components/Grid/components/Row/DatasetRow/components/Tooltip/index.tsx
+++ b/frontend/src/components/Collections/components/Grid/components/Row/DatasetRow/components/Tooltip/index.tsx
@@ -60,7 +60,7 @@ const ERROR_TO_CONTENT: { [key: string]: Content } = {
 
 const DEFAULT_CONTENT: Content = {
   color: RED.C,
-  content: <span>There was an unexpected problem. Please try again.</span>,
+  content: <span>There was an unexpected problem.</span>,
   intent: Intent.DANGER,
 };
 

--- a/tests/unit/backend/corpora/dataset_processing/test_process.py
+++ b/tests/unit/backend/corpora/dataset_processing/test_process.py
@@ -568,11 +568,7 @@ class TestDatasetProcessing(DataPortalTestCase):
     @patch("backend.corpora.dataset_processing.process.validate_h5ad_file")
     @patch("backend.corpora.dataset_processing.process.extract_metadata")
     def test__cxg_not_created_when_metadata_extraction_fails(
-            self,
-            mock_metadata_extraction,
-            mock_validate_h5ad,
-            mock_dropbox_download,
-            mock_cxg
+        self, mock_metadata_extraction, mock_validate_h5ad, mock_dropbox_download, mock_cxg
     ):
         mock_metadata_extraction.side_effect = RuntimeError("metadata extraction failed")
         mock_dropbox_download.return_value = self.h5ad_filename
@@ -589,7 +585,3 @@ class TestDatasetProcessing(DataPortalTestCase):
         dataset = Dataset.get(self.session, dataset_id)
         processing_status = dataset.processing_status
         self.assertEqual(None, processing_status.conversion_cxg_status)
-
-
-
-

--- a/tests/unit/backend/corpora/dataset_processing/test_process.py
+++ b/tests/unit/backend/corpora/dataset_processing/test_process.py
@@ -562,3 +562,34 @@ class TestDatasetProcessing(DataPortalTestCase):
         end = time.time()
         # check that tombstoning ends the download thread early
         self.assertLess(end - start, 11)
+
+    @patch("backend.corpora.dataset_processing.process.make_cxg")
+    @patch("backend.corpora.dataset_processing.process.download_from_dropbox_url")
+    @patch("backend.corpora.dataset_processing.process.validate_h5ad_file")
+    @patch("backend.corpora.dataset_processing.process.extract_metadata")
+    def test__cxg_not_created_when_metadata_extraction_fails(
+            self,
+            mock_metadata_extraction,
+            mock_validate_h5ad,
+            mock_dropbox_download,
+            mock_cxg
+    ):
+        mock_metadata_extraction.side_effect = RuntimeError("metadata extraction failed")
+        mock_dropbox_download.return_value = self.h5ad_filename
+        mock_cxg.return_value = str(self.cxg_filename)
+        dataset = self.generate_dataset(self.session)
+        dataset_id = dataset.id
+
+        explorer_bucket = "CELLXGENE-HOSTED-TEST"
+        artifact_bucket = "test-artifact-bucket"
+
+        with self.assertRaises(RuntimeError):
+            process.process(dataset_id, str(self.h5ad_filename), explorer_bucket, artifact_bucket)
+
+        dataset = Dataset.get(self.session, dataset_id)
+        processing_status = dataset.processing_status
+        self.assertEqual(None, processing_status.conversion_cxg_status)
+
+
+
+


### PR DESCRIPTION
### Reviewers
**Functional:** 

- @danieljhegeman 

---

## Changes

- modify processing script to extract metadata before creating the cxg file


## QA steps (optional)
rdev - https://dunitz-example-frontend.rdev.single-cell.czi.technology/?curator=true
dataset known to fail - https://www.dropbox.com/s/ccnukp6ehra5vei/dead_small_dataset.h5ad?dl=0

