### PR TITLE
chore: Deprecate CREATE_COLLECTION and AUTH feature flags

### DIFF
--- a/frontend/jest/featureFlags.js
+++ b/frontend/jest/featureFlags.js
@@ -5,9 +5,9 @@ module.exports = {
   origins: [
     {
       localStorage: [
-        { name: "cxg-ff-auth", value: "yes" },
-        { name: "cxg-ff-cc", value: "yes" },
         { name: "cxg-ff-gs", value: "yes" },
+        { name: "cxg-ff-curator", value: "yes" },
+        { name: "cxg-ff-rc", value: "yes" },
       ],
       origin: TEST_URL,
     },

--- a/frontend/src/common/featureFlags/features.ts
+++ b/frontend/src/common/featureFlags/features.ts
@@ -1,5 +1,4 @@
 export enum FEATURES {
-  AUTH = "auth",
   GENE_SETS = "gs",
   CURATOR = "curator",
   REVISION = "rc",

--- a/frontend/src/common/featureFlags/features.ts
+++ b/frontend/src/common/featureFlags/features.ts
@@ -1,5 +1,4 @@
 export enum FEATURES {
-  CREATE_COLLECTION = "cc",
   AUTH = "auth",
   GENE_SETS = "gs",
   CURATOR = "curator",

--- a/frontend/src/components/CreateCollectionModal/index.tsx
+++ b/frontend/src/components/CreateCollectionModal/index.tsx
@@ -41,12 +41,7 @@ const CreateCollection: FC<{
   const [isOpen, setIsOpen] = useState(shouldModuleOpen);
   const { data: userInfo, isLoading } = useUserInfo(isAuth || isCurator);
 
-  // (thuang): FEATURES.CREATE_COLLECTION is being deprecated
-  const isCreateCollection = get(FEATURES.CREATE_COLLECTION) === BOOLEAN.TRUE;
-
-  const shouldShowFeature = isCreateCollection || isCurator;
-
-  if (!shouldShowFeature || isLoading) {
+  if (!isCurator || isLoading) {
     return null;
   }
 

--- a/frontend/src/components/CreateCollectionModal/index.tsx
+++ b/frontend/src/components/CreateCollectionModal/index.tsx
@@ -31,7 +31,6 @@ const CreateCollection: FC<{
   id?: Collection["id"];
   Button?: React.ElementType;
 }> = ({ className, id, Button }) => {
-  const isAuth = get(FEATURES.AUTH) === BOOLEAN.TRUE;
   const isCurator = get(FEATURES.CURATOR) === BOOLEAN.TRUE;
   const urlParams = new URLSearchParams(window.location.search);
   const param = urlParams.get(QUERY_PARAMETERS.LOGIN_MODULE_REDIRECT);
@@ -39,7 +38,7 @@ const CreateCollection: FC<{
   const shouldModuleOpen = param?.toLowerCase() === BOOLEAN.TRUE;
 
   const [isOpen, setIsOpen] = useState(shouldModuleOpen);
-  const { data: userInfo, isLoading } = useUserInfo(isAuth || isCurator);
+  const { data: userInfo, isLoading } = useUserInfo(isCurator);
 
   if (!isCurator || isLoading) {
     return null;

--- a/frontend/src/components/Header/components/AuthButtons/index.tsx
+++ b/frontend/src/components/Header/components/AuthButtons/index.tsx
@@ -17,10 +17,7 @@ import { API_URL } from "src/configs/configs";
 import { ButtonWrapper, Initial } from "./style";
 
 const AuthButtons = () => {
-  // (thuang): FEATURES.AUTH is being deprecated
-  const hasAuth =
-    get(FEATURES.AUTH) === BOOLEAN.TRUE ||
-    get(FEATURES.CURATOR) === BOOLEAN.TRUE;
+  const hasAuth = get(FEATURES.CURATOR) === BOOLEAN.TRUE;
 
   const { data: userInfo, isLoading, error } = useUserInfo(hasAuth);
 

--- a/frontend/src/components/Header/index.tsx
+++ b/frontend/src/components/Header/index.tsx
@@ -14,12 +14,11 @@ const Header: FC = () => {
   // (thuang): FEATURES.AUTH and FEATURES.CREATE_COLLECTION are being deprecated
   const isAuth = get(FEATURES.AUTH) === BOOLEAN.TRUE;
   const isCurator = get(FEATURES.CURATOR) === BOOLEAN.TRUE;
-  const isCreateCollection = get(FEATURES.CREATE_COLLECTION) === BOOLEAN.TRUE;
 
   const { data: userInfo } = useUserInfo(isAuth || isCurator);
 
   const isMyCollectionsShown =
-    userInfo?.name && (isCreateCollection || isCurator);
+    userInfo?.name && isCurator;
 
   return (
     <Wrapper>

--- a/frontend/src/components/Header/index.tsx
+++ b/frontend/src/components/Header/index.tsx
@@ -11,11 +11,9 @@ import AuthButtons from "./components/AuthButtons";
 import { MainWrapper, MyCollectionsButton, Right, Wrapper } from "./style";
 
 const Header: FC = () => {
-  // (thuang): FEATURES.AUTH and FEATURES.CREATE_COLLECTION are being deprecated
-  const isAuth = get(FEATURES.AUTH) === BOOLEAN.TRUE;
   const isCurator = get(FEATURES.CURATOR) === BOOLEAN.TRUE;
 
-  const { data: userInfo } = useUserInfo(isAuth || isCurator);
+  const { data: userInfo } = useUserInfo(isCurator);
 
   const isMyCollectionsShown =
     userInfo?.name && isCurator;

--- a/frontend/src/components/Header/index.tsx
+++ b/frontend/src/components/Header/index.tsx
@@ -12,11 +12,9 @@ import { MainWrapper, MyCollectionsButton, Right, Wrapper } from "./style";
 
 const Header: FC = () => {
   const isCurator = get(FEATURES.CURATOR) === BOOLEAN.TRUE;
-
   const { data: userInfo } = useUserInfo(isCurator);
 
-  const isMyCollectionsShown =
-    userInfo?.name && isCurator;
+  const isMyCollectionsShown = userInfo?.name && isCurator;
 
   return (
     <Wrapper>


### PR DESCRIPTION
### Reviewers
**Functional:** 
@seve 

## Changes
- remove `CREATE_COLLECTION` and `AUTH` feature flag and code references

## QA steps (optional)
- Still need to try `rdev`
- Ran locally and checked if buttons are displayed when deprecated feature flags are turned on:

**CREATE_COLLECTIONS ("cc")**
<img width="1792" alt="Screen Shot 2021-08-10 at 09 39 45" src="https://user-images.githubusercontent.com/75650148/128900567-cbca52d4-64a9-41f8-8bcc-ff966f59a825.png">

**AUTH ("auth")**
<img width="1792" alt="Screen Shot 2021-08-10 at 09 40 22" src="https://user-images.githubusercontent.com/75650148/128900632-9ccab1ac-9ae4-4d2f-941f-58774358da8f.png">

**Curator flag works as it should:**
<img width="1792" alt="Screen Shot 2021-08-10 at 09 40 52" src="https://user-images.githubusercontent.com/75650148/128900756-c6da3ce0-427b-4172-82cd-3337048a264b.png">

