### PR TITLE
fix: upload dataset stale download

### DIFF
--- a/frontend/src/components/Collections/components/Grid/components/Row/DatasetRow/utils.ts
+++ b/frontend/src/components/Collections/components/Grid/components/Row/DatasetRow/utils.ts
@@ -71,7 +71,7 @@ export function checkIfFailed(datasetStatus: DatasetUploadStatus): FailReturn {
 export function checkIfMetadataLoading(
   dataset: Dataset,
   datasetStatus: DatasetUploadStatus
-) {
+): boolean {
   const isFailed = checkIfFailed(datasetStatus).isFailed;
   const isNamePopulated = Boolean(dataset.name);
 
@@ -116,7 +116,7 @@ export function useCheckCollectionPopulated({
   isFailed: boolean;
   isNamePopulated: boolean;
   validationStatus: VALIDATION_STATUS;
-}) {
+}): void {
   useCheckCollection({
     invalidateCollectionQuery,
     shouldFetch:
@@ -147,7 +147,7 @@ export function useCheckCollectionFormatsPopulated({
   invalidateCollectionQuery: () => void;
   dataset: Dataset;
   datasetUploadStatus: DatasetUploadStatus;
-}) {
+}): void {
   let numOfConvertedFormats = 0;
 
   for (const key of CONVERSION_STATUS_FORMAT_KEYS) {
@@ -156,13 +156,7 @@ export function useCheckCollectionFormatsPopulated({
     numOfConvertedFormats += 1;
   }
 
-  let numOfAvailableFormats = 0;
-
-  if (dataset.dataset_deployments.length > 0) {
-    numOfAvailableFormats += 1;
-  }
-
-  numOfAvailableFormats = numOfAvailableFormats + dataset.dataset_assets.length;
+  const numOfAvailableFormats = dataset.dataset_assets.length;
 
   useCheckCollection({
     invalidateCollectionQuery,
@@ -206,7 +200,7 @@ export function useCancelDatasetStatusQuery({
   isFailed: boolean;
   isLoading: boolean;
   queryCache: QueryCache;
-}) {
+}): void {
   useEffect(() => {
     if (isFailed || !isLoading) {
       queryCache.cancelQueries([USE_DATASET_STATUS, datasetId]);
@@ -220,7 +214,7 @@ export function useUploadProgress({
 }: {
   initProgress: number;
   progress: number;
-}) {
+}): void {
   useProgress({
     initProgress,
     progress,
@@ -235,7 +229,9 @@ function useUploadProgressSuccessCallback() {
   );
 }
 
-export function getConversionStatus(datasetStatus?: DatasetUploadStatus) {
+export function getConversionStatus(
+  datasetStatus?: DatasetUploadStatus
+): CONVERSION_STATUS {
   if (!datasetStatus) return CONVERSION_STATUS.NA;
 
   const {
@@ -273,7 +269,7 @@ export function useConversionProgress({
 }: {
   initDatasetStatus: DatasetUploadStatus;
   datasetStatus?: DatasetUploadStatus;
-}) {
+}): void {
   const initProgress = isConverted(initDatasetStatus);
   const progress = isConverted(datasetStatus);
 
@@ -292,7 +288,7 @@ function isConverted(status?: DatasetUploadStatus): 0 | 1 {
   return getConversionStatus(status) === CONVERSION_STATUS.CONVERTED ? 1 : 0;
 }
 
-export function hasCXGFile(dataset: Dataset) {
+export function hasCXGFile(dataset: Dataset): boolean {
   const deployments = dataset.dataset_deployments;
 
   if (!deployments || !deployments.length) return false;


### PR DESCRIPTION
RDEV: https://thuang-stale-download-frontend.rdev.single-cell.czi.technology/?rc=true&curator=true

### Reviewers
**Functional:** 
@seve 

---

## Changes
- modify
Looks like CXG is now part of `dataset.dataset_assets`, so we no longer need to rely on `dataset.dataset_deployments` to infer `CXG` has been converted. This is the root cause of the off by one issue that causes the bug!

## Definition of Done (from ticket)

## QA steps (optional)
1. Upload a dataset
2. Wait till the process completes
3. Click download icon to see if all three formats are available (should be)
4. Upload another dataset
5. Wait till the process completes
6. Click download icon to see if all three formats are available <--- this is where the bug was. But now all 3 formats should  be available!

## Known Issues
N/A